### PR TITLE
Ignore two linting warnings that aren't relevant

### DIFF
--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -131,7 +131,7 @@ class SSO {
 			300
 		);
 
-		wp_safe_redirect( $proxy_url );
+		wp_redirect( $proxy_url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
 	}
 


### PR DESCRIPTION
Ignore two linting warnings:

1. wp_redirect is used instead of wp_safe_redirect to allow redirecting to an external URL for logging in.
2. Ignored use of file_get_contents since file is internal to the plugin and warning is about remote files.