### PR TITLE
Add RoleManagement module to extend Editor capabilities

### DIFF
--- a/includes/classes/RoleManagement/RoleManagement.php
+++ b/includes/classes/RoleManagement/RoleManagement.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Role Management
+ *
+ * @package  WordPressTools
+ */
+
+namespace WordPressTools\RoleManagement;
+
+use WordPressTools\Singleton;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Grants additional capabilities to the Editor role:
+ * - All Yoast SEO settings and capabilities
+ * - Full create/edit/delete access to all custom post types
+ */
+class RoleManagement {
+
+	use Singleton;
+
+	/**
+	 * Yoast SEO capabilities to grant editors.
+	 *
+	 * @var string[]
+	 */
+	private const YOAST_CAPS = [
+		'wpseo_manage_options',
+		'wpseo_bulk_edit',
+		'wpseo_edit_advanced_metadata',
+	];
+
+	/**
+	 * CPT capability keys that cover create/edit/delete.
+	 *
+	 * @var string[]
+	 */
+	private const CPT_CAP_KEYS = [
+		'create_posts',
+		'publish_posts',
+		'edit_posts',
+		'edit_others_posts',
+		'edit_published_posts',
+		'edit_private_posts',
+		'delete_posts',
+		'delete_others_posts',
+		'delete_published_posts',
+		'delete_private_posts',
+		'read_private_posts',
+	];
+
+	/**
+	 * Setup module.
+	 */
+	public function setup() {
+		add_filter( 'user_has_cap', [ $this, 'grant_editor_caps' ], 10, 4 );
+	}
+
+	/**
+	 * Dynamically grant extra capabilities to Editor users.
+	 *
+	 * @param bool[]   $allcaps All caps currently assigned to the user.
+	 * @param string[] $caps    Required primitive capabilities for the check.
+	 * @param array    $args    Context: [0] => cap requested, [1] => user ID, ...
+	 * @param \WP_User $user    The user object.
+	 * @return bool[]
+	 */
+	public function grant_editor_caps( $allcaps, $caps, $args, $user ) {
+		if ( ! in_array( 'editor', (array) $user->roles, true ) ) {
+			return $allcaps;
+		}
+
+		foreach ( self::YOAST_CAPS as $cap ) {
+			$allcaps[ $cap ] = true;
+		}
+
+		foreach ( $this->get_custom_post_type_caps() as $cap ) {
+			$allcaps[ $cap ] = true;
+		}
+
+		return $allcaps;
+	}
+
+	/**
+	 * Collect all capability strings across registered non-builtin post types.
+	 *
+	 * @return string[]
+	 */
+	private function get_custom_post_type_caps() {
+		$caps       = [];
+		$post_types = get_post_types( [ '_builtin' => false ], 'objects' );
+
+		foreach ( $post_types as $post_type ) {
+			$type_caps = (array) $post_type->cap;
+
+			foreach ( self::CPT_CAP_KEYS as $key ) {
+				if ( ! empty( $type_caps[ $key ] ) ) {
+					$caps[] = $type_caps[ $key ];
+				}
+			}
+		}
+
+		return array_unique( $caps );
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.6.2",
+	"version": "1.6.3",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -29,6 +29,7 @@ use WordPressTools\API\API;
 use WordPressTools\SiteInfo\ActivityLog;
 use WordPressTools\SiteInfo\SiteInfo;
 use WordPressTools\MCP\MCP;
+use WordPressTools\RoleManagement\RoleManagement;
 use WP_CLI;
 
 // Prevent direct access.
@@ -163,6 +164,7 @@ add_action(
 		SiteInfo::instance();
 		API::instance();
 		MCP::instance();
+		RoleManagement::instance();
 	}
 );
 


### PR DESCRIPTION
Grants Editor role full Yoast SEO access (wpseo_manage_options, wpseo_bulk_edit, wpseo_edit_advanced_metadata) and complete create/edit/delete capabilities for all registered custom post types. Capabilities are applied dynamically via user_has_cap to avoid database writes and automatically cover CPTs from any plugin or theme.