### PR TITLE
Rename whitelist/blacklist terminology to allow list/deny list

### DIFF
--- a/assets/css/settings-user-search.css
+++ b/assets/css/settings-user-search.css
@@ -49,6 +49,10 @@
 	display: none;
 }
 
+.wpt-hidden {
+	display: none;
+}
+
 .wpt-whitelist-container {
 	margin-top: 12px;
 	padding-top: 12px;

--- a/assets/css/settings-user-search.css
+++ b/assets/css/settings-user-search.css
@@ -53,7 +53,7 @@
 	display: none;
 }
 
-.wpt-whitelist-container {
+.wpt-allow-list-container {
 	margin-top: 12px;
 	padding-top: 12px;
 	border-top: 1px solid #f0f0f0;

--- a/assets/js/settings-user-search.js
+++ b/assets/js/settings-user-search.js
@@ -212,7 +212,7 @@
 
 		function updateVisibility( value ) {
 			document.querySelectorAll( '[data-restriction="' + name + '"]' ).forEach( function ( el ) {
-				el.style.display = '1' === value ? '' : 'none';
+				el.classList.toggle( 'wpt-hidden', '1' !== value );
 			} );
 		}
 

--- a/includes/classes/Authentication/TwoFactor.php
+++ b/includes/classes/Authentication/TwoFactor.php
@@ -125,7 +125,7 @@ class TwoFactor {
 	/**
 	 * Restrict capabilities for non-SSO users without 2FA using map_meta_cap.
 	 *
-	 * Uses a whitelist approach: only allowed capabilities pass through,
+	 * Uses an allow-list approach: only allowed capabilities pass through,
 	 * everything else is blocked.
 	 *
 	 * @param array  $caps    The required primitive capabilities.
@@ -150,7 +150,7 @@ class TwoFactor {
 			return $caps;
 		}
 
-		// Only allow whitelisted capabilities, block everything else.
+		// Only allow listed capabilities, block everything else.
 		if ( ! in_array( $cap, self::ALLOWED_CAPABILITIES, true ) ) {
 			return [ 'do_not_allow' ];
 		}

--- a/includes/classes/Authors/Authors.php
+++ b/includes/classes/Authors/Authors.php
@@ -38,12 +38,12 @@ class Authors {
 		$author             = get_queried_object();
 		$current_domain     = wp_parse_url( get_site_url(), PHP_URL_HOST );
 
-		// Domain names that are whitelisted allowed to index 829 Studios users to be indexed
-		$whitelisted_domains = [];
+		// Domain names allowed to index 829 Studios users
+		$allowed_domains = [];
 
 		// Perform partial match on domains to catch subdomains or variation of domain name
 		$filtered_domains = array_filter(
-			$whitelisted_domains,
+			$allowed_domains,
 			function ( $domain ) use ( $current_domain ) {
 				return false !== stripos( $current_domain, $domain );
 			}

--- a/includes/classes/PluginManagement/PluginManagement.php
+++ b/includes/classes/PluginManagement/PluginManagement.php
@@ -92,10 +92,10 @@ class PluginManagement {
 			return false;
 		}
 
-		$whitelist = ! empty( $settings['plugin_management_whitelist'] ) ? array_map( 'intval', (array) $settings['plugin_management_whitelist'] ) : [];
-		if ( ! empty( $whitelist ) ) {
+		$allow_list = ! empty( $settings['plugin_management_allow_list'] ) ? array_map( 'intval', (array) $settings['plugin_management_allow_list'] ) : [];
+		if ( ! empty( $allow_list ) ) {
 			$uid = $user_id ? (int) $user_id : get_current_user_id();
-			if ( in_array( $uid, $whitelist, true ) ) {
+			if ( in_array( $uid, $allow_list, true ) ) {
 				return false;
 			}
 		}
@@ -120,10 +120,10 @@ class PluginManagement {
 			return false;
 		}
 
-		$whitelist = ! empty( $settings['theme_management_whitelist'] ) ? array_map( 'intval', (array) $settings['theme_management_whitelist'] ) : [];
-		if ( ! empty( $whitelist ) ) {
+		$allow_list = ! empty( $settings['theme_management_allow_list'] ) ? array_map( 'intval', (array) $settings['theme_management_allow_list'] ) : [];
+		if ( ! empty( $allow_list ) ) {
 			$uid = $user_id ? (int) $user_id : get_current_user_id();
-			if ( in_array( $uid, $whitelist, true ) ) {
+			if ( in_array( $uid, $allow_list, true ) ) {
 				return false;
 			}
 		}
@@ -205,11 +205,11 @@ class PluginManagement {
 			return $caps;
 		}
 
-		$whitelist_key = $is_plugin_cap ? 'plugin_management_whitelist' : 'theme_management_whitelist';
-		$whitelist     = ! empty( $settings[ $whitelist_key ] ) ? array_map( 'intval', (array) $settings[ $whitelist_key ] ) : [];
+		$allow_list_key = $is_plugin_cap ? 'plugin_management_allow_list' : 'theme_management_allow_list';
+		$allow_list     = ! empty( $settings[ $allow_list_key ] ) ? array_map( 'intval', (array) $settings[ $allow_list_key ] ) : [];
 		$uid           = $user_id ? (int) $user_id : get_current_user_id();
 
-		if ( ! empty( $whitelist ) && in_array( $uid, $whitelist, true ) ) {
+		if ( ! empty( $allow_list ) && in_array( $uid, $allow_list, true ) ) {
 			return []; // Empty caps array grants access regardless of user role.
 		}
 

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -403,11 +403,11 @@ class SSO {
 			return $user;
 		}
 
-		$whitelist = ! empty( $settings['credential_login_whitelist'] )
-			? array_map( 'intval', (array) $settings['credential_login_whitelist'] )
+		$allow_list = ! empty( $settings['credential_login_allow_list'] )
+			? array_map( 'intval', (array) $settings['credential_login_allow_list'] )
 			: [];
 
-		if ( ! empty( $whitelist ) && in_array( (int) $user->ID, $whitelist, true ) ) {
+		if ( ! empty( $allow_list ) && in_array( (int) $user->ID, $allow_list, true ) ) {
 			return $user;
 		}
 

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -33,6 +33,8 @@ class SSO {
 	 * Setup SSO
 	 */
 	public function __construct() {
+		// Always enforce domain-based credential restriction regardless of SSO state.
+		add_filter( 'authenticate', [ $this, 'block_829_domain_credential_login' ], 30 );
 
 		if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) {
 			return;
@@ -366,6 +368,53 @@ class SSO {
 			<?php endif; ?>
 		</style>
 		<?php
+	}
+
+	/**
+	 * Block credential login for @829llc.com and @829studios.com accounts.
+	 *
+	 * Runs at authenticate priority 30 (after core credential check at 20).
+	 * Fires regardless of SSO enabled/disabled state.
+	 *
+	 * @param WP_User|WP_Error|null $user Result from credential check.
+	 * @return WP_User|WP_Error
+	 */
+	public function block_829_domain_credential_login( $user ) {
+		if ( is_wp_error( $user ) || ! ( $user instanceof \WP_User ) ) {
+			return $user;
+		}
+
+		// When SSO itself is disabled there is no alternative login path, so
+		// enforcing the credential restriction would permanently lock 829 users out.
+		if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) {
+			return $user;
+		}
+
+		$settings = Settings::get_settings();
+
+		if ( empty( $settings['restrict_829_credential_login'] ) ) {
+			return $user;
+		}
+
+		$restricted_domains = [ '829llc.com', '829studios.com' ];
+		$email_domain       = strtolower( substr( strrchr( $user->user_email, '@' ), 1 ) );
+
+		if ( ! in_array( $email_domain, $restricted_domains, true ) ) {
+			return $user;
+		}
+
+		$whitelist = ! empty( $settings['credential_login_whitelist'] )
+			? array_map( 'intval', (array) $settings['credential_login_whitelist'] )
+			: [];
+
+		if ( ! empty( $whitelist ) && in_array( (int) $user->ID, $whitelist, true ) ) {
+			return $user;
+		}
+
+		return new WP_Error(
+			'wpt-829-domain-login',
+			esc_html__( 'Users with @829llc.com or @829studios.com email addresses must sign in using Okta.', 'wordpress-tools' )
+		);
 	}
 
 	/**

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -51,14 +51,14 @@ class Settings {
 		$defaults = [
 			'allow_sso'                      => 1,
 			'restrict_829_credential_login'  => 1,
-			'credential_login_whitelist'     => [],
+			'credential_login_allow_list'     => [],
 			'disable_comments'               => 0,
 			'require_strong_passwords'       => 1,
 			'password_protect'               => 0,
 			'restrict_plugin_management'     => 1,
-			'plugin_management_whitelist'    => [],
+			'plugin_management_allow_list'    => [],
 			'restrict_theme_management'      => 1,
-			'theme_management_whitelist'     => [],
+			'theme_management_allow_list'     => [],
 			'restrict_rest_api'              => 'users',
 			'limit_login'                    => 1,
 			'enable_mcp'                     => 1,
@@ -69,6 +69,28 @@ class Settings {
 			$settings = get_site_option( 'wpt_settings', [] );
 		} else {
 			$settings = get_option( 'wpt_settings', [] );
+		}
+
+		// One-time migration: rename legacy *_whitelist keys to *_allow_list.
+		$legacy_keys = [
+			'credential_login_whitelist'  => 'credential_login_allow_list',
+			'plugin_management_whitelist' => 'plugin_management_allow_list',
+			'theme_management_whitelist'  => 'theme_management_allow_list',
+		];
+		$migrated = false;
+		foreach ( $legacy_keys as $old => $new ) {
+			if ( array_key_exists( $old, $settings ) ) {
+				$settings[ $new ] = $settings[ $old ];
+				unset( $settings[ $old ] );
+				$migrated = true;
+			}
+		}
+		if ( $migrated ) {
+			if ( WPT_IS_NETWORK ) {
+				update_site_option( 'wpt_settings', $settings );
+			} else {
+				update_option( 'wpt_settings', $settings );
+			}
 		}
 
 		// Merge with defaults to ensure all keys exist
@@ -183,14 +205,14 @@ class Settings {
 				'default'           => [
 					'allow_sso'                     => 1,
 					'restrict_829_credential_login' => 1,
-					'credential_login_whitelist'    => [],
+					'credential_login_allow_list'    => [],
 					'disable_comments'              => 0,
 					'require_strong_passwords'      => 1,
 					'password_protect'              => 0,
 					'restrict_plugin_management'    => 1,
-					'plugin_management_whitelist'   => [],
+					'plugin_management_allow_list'   => [],
 					'restrict_theme_management'     => 1,
-					'theme_management_whitelist'    => [],
+					'theme_management_allow_list'    => [],
 					'restrict_rest_api'             => 'users',
 					'limit_login'                   => 1,
 					'enable_mcp'                    => 1,
@@ -340,17 +362,17 @@ class Settings {
 	public function restrict_829_credential_login_setting_callback() {
 		$settings  = self::get_settings();
 		$restrict  = $settings['restrict_829_credential_login'];
-		$whitelist = $settings['credential_login_whitelist'] ?? [];
-		$this->render_credential_login_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['credential_login_allow_list'] ?? [];
+		$this->render_credential_login_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict 829 Credential Login setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_credential_login_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_credential_login_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-829-credential-login-yes" name="wpt_settings[restrict_829_credential_login]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -367,10 +389,10 @@ class Settings {
 				<p class="description" style="color:#d63638;margin-top:4px;"><?php esc_html_e( 'Warning: SSO is currently disabled (WPT_SSO_DISABLE). This restriction will not be enforced until SSO is re-enabled, to prevent lockout.', 'wordpress-tools' ); ?></p>
 			<?php endif; ?>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Credential Login Exceptions', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can still log in with credentials even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'credential_login_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'credential_login_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -379,7 +401,7 @@ class Settings {
 	/**
 	 * Render a user search field with tag-style selected users.
 	 *
-	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param string $setting_key Settings key for the allow list array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
 	protected function render_user_search_field( $setting_key, $user_ids ) {
@@ -473,17 +495,17 @@ class Settings {
 	public function restrict_plugin_management_setting_callback() {
 		$settings = self::get_settings();
 		$restrict  = $settings['restrict_plugin_management'];
-		$whitelist = $settings['plugin_management_whitelist'] ?? [];
-		$this->render_plugin_management_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['plugin_management_allow_list'] ?? [];
+		$this->render_plugin_management_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict Plugin Management setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_plugin_management_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_plugin_management_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -497,10 +519,10 @@ class Settings {
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
-				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Allowed Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'plugin_management_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'plugin_management_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -512,17 +534,17 @@ class Settings {
 	public function restrict_theme_management_setting_callback() {
 		$settings  = self::get_settings();
 		$restrict  = $settings['restrict_theme_management'];
-		$whitelist = $settings['theme_management_whitelist'] ?? [];
-		$this->render_theme_management_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['theme_management_allow_list'] ?? [];
+		$this->render_theme_management_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict Theme Management setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_theme_management_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_theme_management_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -536,10 +558,10 @@ class Settings {
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
-				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Allowed Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'theme_management_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'theme_management_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -548,7 +570,7 @@ class Settings {
 	/**
 	 * Render a user search field with tag-style selected users.
 	 *
-	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param string $setting_key Settings key for the allow list array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
 	/**
@@ -771,9 +793,9 @@ class Settings {
 		// Sanitize restrict_829_credential_login (defaults to 1/on when missing)
 		$sanitized['restrict_829_credential_login'] = isset( $input['restrict_829_credential_login'] ) ? intval( $input['restrict_829_credential_login'] ) : 1;
 
-		// Sanitize credential_login_whitelist — drops IDs for deleted users
-		$sanitized['credential_login_whitelist'] = isset( $input['credential_login_whitelist'] )
-			? $this->sanitize_user_id_list( $input['credential_login_whitelist'] )
+		// Sanitize credential_login_allow_list — drops IDs for deleted users
+		$sanitized['credential_login_allow_list'] = isset( $input['credential_login_allow_list'] )
+			? $this->sanitize_user_id_list( $input['credential_login_allow_list'] )
 			: [];
 
 		// Sanitize disable_comments
@@ -788,17 +810,17 @@ class Settings {
 		// Sanitize restrict_plugin_management
 		$sanitized['restrict_plugin_management'] = isset( $input['restrict_plugin_management'] ) ? intval( $input['restrict_plugin_management'] ) : 0;
 
-		// Sanitize plugin_management_whitelist — drops IDs for deleted users
-		$sanitized['plugin_management_whitelist'] = isset( $input['plugin_management_whitelist'] )
-			? $this->sanitize_user_id_list( $input['plugin_management_whitelist'] )
+		// Sanitize plugin_management_allow_list — drops IDs for deleted users
+		$sanitized['plugin_management_allow_list'] = isset( $input['plugin_management_allow_list'] )
+			? $this->sanitize_user_id_list( $input['plugin_management_allow_list'] )
 			: [];
 
 		// Sanitize restrict_theme_management
 		$sanitized['restrict_theme_management'] = isset( $input['restrict_theme_management'] ) ? intval( $input['restrict_theme_management'] ) : 0;
 
-		// Sanitize theme_management_whitelist — drops IDs for deleted users
-		$sanitized['theme_management_whitelist'] = isset( $input['theme_management_whitelist'] )
-			? $this->sanitize_user_id_list( $input['theme_management_whitelist'] )
+		// Sanitize theme_management_allow_list — drops IDs for deleted users
+		$sanitized['theme_management_allow_list'] = isset( $input['theme_management_allow_list'] )
+			? $this->sanitize_user_id_list( $input['theme_management_allow_list'] )
 			: [];
 
 		// Sanitize restrict_rest_api
@@ -973,14 +995,14 @@ class Settings {
 		$settings                        = self::get_settings();
 		$allow_sso                       = $settings['allow_sso'];
 		$restrict_829_credential_login   = $settings['restrict_829_credential_login'];
-		$credential_login_whitelist      = isset( $settings['credential_login_whitelist'] ) ? $settings['credential_login_whitelist'] : [];
+		$credential_login_allow_list      = isset( $settings['credential_login_allow_list'] ) ? $settings['credential_login_allow_list'] : [];
 		$disable_comments                = $settings['disable_comments'];
 		$require_strong_passwords        = $settings['require_strong_passwords'];
 		$password_protect                = $settings['password_protect'];
 		$restrict_plugin_management      = $settings['restrict_plugin_management'];
-		$plugin_management_whitelist     = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$plugin_management_allow_list     = isset( $settings['plugin_management_allow_list'] ) ? $settings['plugin_management_allow_list'] : [];
 		$restrict_theme_management       = $settings['restrict_theme_management'];
-		$theme_management_whitelist      = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$theme_management_allow_list      = isset( $settings['theme_management_allow_list'] ) ? $settings['theme_management_allow_list'] : [];
 		$restrict_rest_api               = $settings['restrict_rest_api'];
 		$limit_login                     = $settings['limit_login'];
 		$enable_mcp                      = $settings['enable_mcp'];
@@ -1030,7 +1052,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict 829 Credential Login', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_whitelist ); ?>
+								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1090,7 +1112,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Plugin Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_whitelist ); ?>
+								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1098,7 +1120,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Theme Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_whitelist ); ?>
+								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -49,17 +49,19 @@ class Settings {
 	 */
 	public static function get_settings() {
 		$defaults = [
-			'allow_sso'                    => 1,
-			'disable_comments'             => 0,
-			'require_strong_passwords'     => 1,
-			'password_protect'             => 0,
-			'restrict_plugin_management'   => 1,
-			'plugin_management_whitelist'  => [],
-			'restrict_theme_management'    => 1,
-			'theme_management_whitelist'   => [],
-			'restrict_rest_api'            => 'users',
-			'limit_login'                  => 1,
-			'enable_mcp'                   => 1,
+			'allow_sso'                      => 1,
+			'restrict_829_credential_login'  => 1,
+			'credential_login_whitelist'     => [],
+			'disable_comments'               => 0,
+			'require_strong_passwords'       => 1,
+			'password_protect'               => 0,
+			'restrict_plugin_management'     => 1,
+			'plugin_management_whitelist'    => [],
+			'restrict_theme_management'      => 1,
+			'theme_management_whitelist'     => [],
+			'restrict_rest_api'              => 'users',
+			'limit_login'                    => 1,
+			'enable_mcp'                     => 1,
 		];
 
 		// Get settings from single option
@@ -179,17 +181,19 @@ class Settings {
 				'type'              => 'array',
 				'sanitize_callback' => [ $this, 'sanitize_settings' ],
 				'default'           => [
-					'allow_sso'                   => 1,
-					'disable_comments'            => 0,
-					'require_strong_passwords'    => 1,
-					'password_protect'            => 0,
-					'restrict_plugin_management'  => 0,
-					'plugin_management_whitelist' => [],
-					'restrict_theme_management'   => 0,
-					'theme_management_whitelist'  => [],
-					'restrict_rest_api'           => 'users',
-					'limit_login'                 => 1,
-					'enable_mcp'                  => 1,
+					'allow_sso'                     => 1,
+					'restrict_829_credential_login' => 1,
+					'credential_login_whitelist'    => [],
+					'disable_comments'              => 0,
+					'require_strong_passwords'      => 1,
+					'password_protect'              => 0,
+					'restrict_plugin_management'    => 1,
+					'plugin_management_whitelist'   => [],
+					'restrict_theme_management'     => 1,
+					'theme_management_whitelist'    => [],
+					'restrict_rest_api'             => 'users',
+					'limit_login'                   => 1,
+					'enable_mcp'                    => 1,
 				],
 			]
 		);
@@ -206,6 +210,15 @@ class Settings {
 			'wpt_allow_sso',
 			esc_html__( 'Allow 829 Studios SSO', 'wordpress-tools' ),
 			[ $this, 'sso_setting_callback' ],
+			'wpt-829-settings',
+			'wpt_829_general_section'
+		);
+
+		// Restrict 829 Credential Login setting field
+		add_settings_field(
+			'wpt_restrict_829_credential_login',
+			esc_html__( 'Restrict 829 Credential Login', 'wordpress-tools' ),
+			[ $this, 'restrict_829_credential_login_setting_callback' ],
 			'wpt-829-settings',
 			'wpt_829_general_section'
 		);
@@ -322,6 +335,77 @@ class Settings {
 	}
 
 	/**
+	 * Restrict 829 Credential Login setting callback.
+	 */
+	public function restrict_829_credential_login_setting_callback() {
+		$settings  = self::get_settings();
+		$restrict  = $settings['restrict_829_credential_login'];
+		$whitelist = $settings['credential_login_whitelist'] ?? [];
+		$this->render_credential_login_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict 829 Credential Login setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_credential_login_restriction_field( int $restrict, array $whitelist ): void {
+		?>
+		<fieldset>
+			<input id="wpt-restrict-829-credential-login-yes" name="wpt_settings[restrict_829_credential_login]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
+			<label for="wpt-restrict-829-credential-login-yes">
+				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
+			</label><br>
+
+			<input id="wpt-restrict-829-credential-login-no" name="wpt_settings[restrict_829_credential_login]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
+			<label for="wpt-restrict-829-credential-login-no">
+				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Prevents users with @829llc.com or @829studios.com email addresses from logging in with username/password. They must use Okta SSO.', 'wordpress-tools' ); ?></p>
+			<?php if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) : ?>
+				<p class="description" style="color:#d63638;margin-top:4px;"><?php esc_html_e( 'Warning: SSO is currently disabled (WPT_SSO_DISABLE). This restriction will not be enforced until SSO is re-enabled, to prevent lockout.', 'wordpress-tools' ); ?></p>
+			<?php endif; ?>
+
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Credential Login Exceptions', 'wordpress-tools' ); ?></strong></p>
+				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can still log in with credentials even when restriction is enabled.', 'wordpress-tools' ); ?></p>
+				<?php $this->render_user_search_field( 'credential_login_whitelist', $whitelist ); ?>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render a user search field with tag-style selected users.
+	 *
+	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param array  $user_ids    Currently saved user IDs.
+	 */
+	protected function render_user_search_field( $setting_key, $user_ids ) {
+		$user_ids = array_filter( array_map( 'intval', (array) $user_ids ) );
+		$users    = ! empty( $user_ids ) ? get_users( [ 'include' => $user_ids ] ) : [];
+		?>
+		<div class="wpt-user-search" data-setting-key="<?php echo esc_attr( $setting_key ); ?>">
+			<div class="wpt-user-tags">
+				<?php foreach ( $users as $user ) : ?>
+					<span class="wpt-user-tag">
+						<span class="wpt-user-tag-label"><?php echo esc_html( $user->display_name . ' (' . $user->user_email . ')' ); ?></span>
+						<button type="button" class="wpt-user-tag-remove" data-user-id="<?php echo esc_attr( $user->ID ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Remove %s', 'wordpress-tools' ), $user->display_name ) ); ?>">&times;</button>
+					</span>
+				<?php endforeach; ?>
+			</div>
+			<div class="wpt-user-ids">
+				<?php foreach ( $user_ids as $uid ) : ?>
+					<input type="hidden" name="wpt_settings[<?php echo esc_attr( $setting_key ); ?>][]" value="<?php echo esc_attr( $uid ); ?>" />
+				<?php endforeach; ?>
+			</div>
+			<input type="text" class="wpt-user-search-input regular-text" placeholder="<?php esc_attr_e( 'Search users…', 'wordpress-tools' ); ?>" autocomplete="off" />
+		</div>
+		<?php
+	}
+
+	/**
 	 * Comments setting callback.
 	 */
 	public function comments_setting_callback() {
@@ -387,23 +471,33 @@ class Settings {
 	 * Restrict Plugin Management setting callback.
 	 */
 	public function restrict_plugin_management_setting_callback() {
-		$settings                   = self::get_settings();
-		$restrict_plugin_management = $settings['restrict_plugin_management'];
-		$whitelist                  = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$settings = self::get_settings();
+		$restrict  = $settings['restrict_plugin_management'];
+		$whitelist = $settings['plugin_management_whitelist'] ?? [];
+		$this->render_plugin_management_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict Plugin Management setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_plugin_management_restriction_field( int $restrict, array $whitelist ): void {
 		?>
 		<fieldset>
-			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict_plugin_management ); ?> />
+			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
 			<label for="wpt-restrict-plugin-management-yes">
 				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
 			</label><br>
 
-			<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict_plugin_management ); ?> />
+			<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
 			<label for="wpt-restrict-plugin-management-no">
 				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container" data-restriction="restrict_plugin_management"<?php echo $restrict_plugin_management ? '' : ' style="display:none"'; ?>>
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
 				<?php $this->render_user_search_field( 'plugin_management_whitelist', $whitelist ); ?>
@@ -416,23 +510,33 @@ class Settings {
 	 * Restrict Theme Management setting callback.
 	 */
 	public function restrict_theme_management_setting_callback() {
-		$settings                  = self::get_settings();
-		$restrict_theme_management = $settings['restrict_theme_management'];
-		$whitelist                 = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$settings  = self::get_settings();
+		$restrict  = $settings['restrict_theme_management'];
+		$whitelist = $settings['theme_management_whitelist'] ?? [];
+		$this->render_theme_management_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict Theme Management setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_theme_management_restriction_field( int $restrict, array $whitelist ): void {
 		?>
 		<fieldset>
-			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict_theme_management ); ?> />
+			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
 			<label for="wpt-restrict-theme-management-yes">
 				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
 			</label><br>
 
-			<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict_theme_management ); ?> />
+			<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
 			<label for="wpt-restrict-theme-management-no">
 				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container" data-restriction="restrict_theme_management"<?php echo $restrict_theme_management ? '' : ' style="display:none"'; ?>>
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
 				<?php $this->render_user_search_field( 'theme_management_whitelist', $whitelist ); ?>
@@ -447,29 +551,6 @@ class Settings {
 	 * @param string $setting_key Settings key for the whitelist array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
-	protected function render_user_search_field( $setting_key, $user_ids ) {
-		$user_ids = array_filter( array_map( 'intval', (array) $user_ids ) );
-		$users    = ! empty( $user_ids ) ? get_users( [ 'include' => $user_ids ] ) : [];
-		?>
-		<div class="wpt-user-search" data-setting-key="<?php echo esc_attr( $setting_key ); ?>">
-			<div class="wpt-user-tags">
-				<?php foreach ( $users as $user ) : ?>
-					<span class="wpt-user-tag">
-						<span class="wpt-user-tag-label"><?php echo esc_html( $user->display_name . ' (' . $user->user_email . ')' ); ?></span>
-						<button type="button" class="wpt-user-tag-remove" data-user-id="<?php echo esc_attr( $user->ID ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Remove %s', 'wordpress-tools' ), $user->display_name ) ); ?>">&times;</button>
-					</span>
-				<?php endforeach; ?>
-			</div>
-			<div class="wpt-user-ids">
-				<?php foreach ( $user_ids as $uid ) : ?>
-					<input type="hidden" name="wpt_settings[<?php echo esc_attr( $setting_key ); ?>][]" value="<?php echo esc_attr( $uid ); ?>" />
-				<?php endforeach; ?>
-			</div>
-			<input type="text" class="wpt-user-search-input regular-text" placeholder="<?php esc_attr_e( 'Search users…', 'wordpress-tools' ); ?>" autocomplete="off" />
-		</div>
-		<?php
-	}
-
 	/**
 	 * REST API Restriction setting callback.
 	 */
@@ -661,6 +742,21 @@ class Settings {
 	}
 
 	/**
+	 * Convert a raw list of user IDs to a clean array of ints, dropping any
+	 * IDs that no longer correspond to an existing WordPress user.
+	 *
+	 * @param  mixed $ids Raw value from form input.
+	 * @return array      Validated, re-indexed array of user IDs.
+	 */
+	private function sanitize_user_id_list( $ids ): array {
+		$ids = array_values( array_filter( array_map( 'intval', (array) $ids ) ) );
+		if ( empty( $ids ) ) {
+			return [];
+		}
+		return array_map( 'intval', get_users( [ 'include' => $ids, 'fields' => 'ID', 'number' => count( $ids ) ] ) );
+	}
+
+	/**
 	 * Sanitize all settings.
 	 *
 	 * @param  array $input Raw input values.
@@ -671,6 +767,14 @@ class Settings {
 
 		// Sanitize allow_sso
 		$sanitized['allow_sso'] = isset( $input['allow_sso'] ) ? intval( $input['allow_sso'] ) : 1;
+
+		// Sanitize restrict_829_credential_login (defaults to 1/on when missing)
+		$sanitized['restrict_829_credential_login'] = isset( $input['restrict_829_credential_login'] ) ? intval( $input['restrict_829_credential_login'] ) : 1;
+
+		// Sanitize credential_login_whitelist — drops IDs for deleted users
+		$sanitized['credential_login_whitelist'] = isset( $input['credential_login_whitelist'] )
+			? $this->sanitize_user_id_list( $input['credential_login_whitelist'] )
+			: [];
 
 		// Sanitize disable_comments
 		$sanitized['disable_comments'] = isset( $input['disable_comments'] ) ? intval( $input['disable_comments'] ) : 0;
@@ -684,17 +788,17 @@ class Settings {
 		// Sanitize restrict_plugin_management
 		$sanitized['restrict_plugin_management'] = isset( $input['restrict_plugin_management'] ) ? intval( $input['restrict_plugin_management'] ) : 0;
 
-		// Sanitize plugin_management_whitelist
+		// Sanitize plugin_management_whitelist — drops IDs for deleted users
 		$sanitized['plugin_management_whitelist'] = isset( $input['plugin_management_whitelist'] )
-			? array_values( array_filter( array_map( 'intval', (array) $input['plugin_management_whitelist'] ) ) )
+			? $this->sanitize_user_id_list( $input['plugin_management_whitelist'] )
 			: [];
 
 		// Sanitize restrict_theme_management
 		$sanitized['restrict_theme_management'] = isset( $input['restrict_theme_management'] ) ? intval( $input['restrict_theme_management'] ) : 0;
 
-		// Sanitize theme_management_whitelist
+		// Sanitize theme_management_whitelist — drops IDs for deleted users
 		$sanitized['theme_management_whitelist'] = isset( $input['theme_management_whitelist'] )
-			? array_values( array_filter( array_map( 'intval', (array) $input['theme_management_whitelist'] ) ) )
+			? $this->sanitize_user_id_list( $input['theme_management_whitelist'] )
 			: [];
 
 		// Sanitize restrict_rest_api
@@ -866,18 +970,20 @@ class Settings {
 			wp_die( esc_html__( 'You do not have permission to access this page.', 'wordpress-tools' ) );
 		}
 
-		$settings                    = self::get_settings();
-		$allow_sso                   = $settings['allow_sso'];
-		$disable_comments            = $settings['disable_comments'];
-		$require_strong_passwords    = $settings['require_strong_passwords'];
-		$password_protect            = $settings['password_protect'];
-		$restrict_plugin_management  = $settings['restrict_plugin_management'];
-		$plugin_management_whitelist = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
-		$restrict_theme_management   = $settings['restrict_theme_management'];
-		$theme_management_whitelist  = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
-		$restrict_rest_api           = $settings['restrict_rest_api'];
-		$limit_login                = $settings['limit_login'];
-		$enable_mcp                 = $settings['enable_mcp'];
+		$settings                        = self::get_settings();
+		$allow_sso                       = $settings['allow_sso'];
+		$restrict_829_credential_login   = $settings['restrict_829_credential_login'];
+		$credential_login_whitelist      = isset( $settings['credential_login_whitelist'] ) ? $settings['credential_login_whitelist'] : [];
+		$disable_comments                = $settings['disable_comments'];
+		$require_strong_passwords        = $settings['require_strong_passwords'];
+		$password_protect                = $settings['password_protect'];
+		$restrict_plugin_management      = $settings['restrict_plugin_management'];
+		$plugin_management_whitelist     = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$restrict_theme_management       = $settings['restrict_theme_management'];
+		$theme_management_whitelist      = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$restrict_rest_api               = $settings['restrict_rest_api'];
+		$limit_login                     = $settings['limit_login'];
+		$enable_mcp                      = $settings['enable_mcp'];
 		$attempt_limit              = defined( 'WPT_LOGIN_ATTEMPT_LIMIT' ) ? WPT_LOGIN_ATTEMPT_LIMIT : 10;
 		$lockout_minutes            = defined( 'WPT_LOGIN_LOCKOUT_DURATION' ) ? ceil( WPT_LOGIN_LOCKOUT_DURATION / 60 ) : 15;
 		$is_disabled                = defined( 'WPT_DISABLE_COMMENTS' ) || has_filter( 'wpt_disable_comments' );
@@ -917,6 +1023,14 @@ class Settings {
 									</label>
 									<p class="description"><?php esc_html_e( 'This allows members of 829 Studios to log in via SSO. This is extremely important to streamline maintenance of your website.', 'wordpress-tools' ); ?></p>
 								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<?php esc_html_e( 'Restrict 829 Credential Login', 'wordpress-tools' ); ?>
+							</th>
+							<td>
+								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -976,24 +1090,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Plugin Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<fieldset>
-									<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict_plugin_management ); ?> />
-									<label for="wpt-restrict-plugin-management-yes">
-										<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
-									</label><br>
-
-									<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict_plugin_management ); ?> />
-									<label for="wpt-restrict-plugin-management-no">
-										<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
-									</label>
-									<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
-
-									<div class="wpt-whitelist-container" data-restriction="restrict_plugin_management"<?php echo $restrict_plugin_management ? '' : ' style="display:none"'; ?>>
-										<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
-										<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-										<?php $this->render_user_search_field( 'plugin_management_whitelist', $plugin_management_whitelist ); ?>
-									</div>
-								</fieldset>
+								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1001,24 +1098,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Theme Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<fieldset>
-									<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict_theme_management ); ?> />
-									<label for="wpt-restrict-theme-management-yes">
-										<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
-									</label><br>
-
-									<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict_theme_management ); ?> />
-									<label for="wpt-restrict-theme-management-no">
-										<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
-									</label>
-									<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
-
-									<div class="wpt-whitelist-container" data-restriction="restrict_theme_management"<?php echo $restrict_theme_management ? '' : ' style="display:none"'; ?>>
-										<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
-										<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-										<?php $this->render_user_search_field( 'theme_management_whitelist', $theme_management_whitelist ); ?>
-									</div>
-								</fieldset>
+								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.7.0
+ * Version: 1.8.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools


### PR DESCRIPTION
Replaces all whitelist terminology across the codebase with inclusive allow-list language. Includes a one-time DB migration so existing installations preserve their saved user lists on first load after update.