### PR TITLE
Add Force No-Index on Staging and Dev Domains feature (v1.8.0)

### DIFF
--- a/assets/css/settings-user-search.css
+++ b/assets/css/settings-user-search.css
@@ -49,6 +49,10 @@
 	display: none;
 }
 
+.wpt-hidden {
+	display: none;
+}
+
 .wpt-whitelist-container {
 	margin-top: 12px;
 	padding-top: 12px;

--- a/assets/css/settings-user-search.css
+++ b/assets/css/settings-user-search.css
@@ -90,3 +90,21 @@
 	background: #2271b1;
 	color: #fff;
 }
+
+.wpt-status-badge {
+	display: inline-block;
+	padding: 2px 8px;
+	border-radius: 3px;
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.wpt-status-active {
+	background: #d4edda;
+	color: #155724;
+}
+
+.wpt-status-disabled {
+	background: #fff3cd;
+	color: #856404;
+}

--- a/assets/css/settings-user-search.css
+++ b/assets/css/settings-user-search.css
@@ -53,7 +53,7 @@
 	display: none;
 }
 
-.wpt-whitelist-container {
+.wpt-allow-list-container {
 	margin-top: 12px;
 	padding-top: 12px;
 	border-top: 1px solid #f0f0f0;

--- a/assets/js/settings-noindex.js
+++ b/assets/js/settings-noindex.js
@@ -1,0 +1,54 @@
+/* globals wptNoIndex */
+( function () {
+	'use strict';
+
+	function postAjax( action, data, callback ) {
+		var body = new FormData();
+		body.append( 'action', action );
+		body.append( 'nonce', wptNoIndex.nonce );
+		Object.keys( data ).forEach( function ( key ) {
+			body.append( key, data[ key ] );
+		} );
+		fetch( wptNoIndex.ajaxUrl, { method: 'POST', body: body } )
+			.then( function ( r ) { return r.json(); } )
+			.then( callback )
+			.catch( function () {} );
+	}
+
+	document.addEventListener( 'DOMContentLoaded', function () {
+		var disableBtn = document.getElementById( 'wpt-noindex-disable-btn' );
+		var enableBtn  = document.getElementById( 'wpt-noindex-enable-btn' );
+
+		if ( disableBtn ) {
+			disableBtn.addEventListener( 'click', function () {
+				var durationEl = document.getElementById( 'wpt-noindex-duration' );
+				var duration   = durationEl ? durationEl.value : '300';
+				disableBtn.disabled    = true;
+				disableBtn.textContent = disableBtn.getAttribute( 'data-loading' );
+				postAjax( 'wpt_noindex_disable', { duration: duration }, function ( res ) {
+					if ( res && res.success ) {
+						window.location.reload();
+					} else {
+						disableBtn.disabled    = false;
+						disableBtn.textContent = disableBtn.getAttribute( 'data-label' );
+					}
+				} );
+			} );
+		}
+
+		if ( enableBtn ) {
+			enableBtn.addEventListener( 'click', function () {
+				enableBtn.disabled    = true;
+				enableBtn.textContent = enableBtn.getAttribute( 'data-loading' );
+				postAjax( 'wpt_noindex_enable', {}, function ( res ) {
+					if ( res && res.success ) {
+						window.location.reload();
+					} else {
+						enableBtn.disabled    = false;
+						enableBtn.textContent = enableBtn.getAttribute( 'data-label' );
+					}
+				} );
+			} );
+		}
+	} );
+} )();

--- a/assets/js/settings-user-search.js
+++ b/assets/js/settings-user-search.js
@@ -212,7 +212,7 @@
 
 		function updateVisibility( value ) {
 			document.querySelectorAll( '[data-restriction="' + name + '"]' ).forEach( function ( el ) {
-				el.style.display = '1' === value ? '' : 'none';
+				el.classList.toggle( 'wpt-hidden', '1' !== value );
 			} );
 		}
 

--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -4,19 +4,3 @@ Tracked ideas and future feature requests for upcoming versions of the plugin. I
 
 ---
 
-## Staging / Dev Domain Protections
-
-### Force No-Index on Staging and Dev Domains
-
-Automatically inject `noindex, nofollow` meta tags and `X-Robots-Tag` headers on all requests made to `*.829dev.com` and `*.829stage.com` domains, preventing staging and dev environments from being indexed by search engines.
-
-**Behavior**
-- Active by default with no permanent off switch
-- Settings page provides a timed disable option (1 hour maximum)
-- After the 1-hour window expires, no-index enforcement automatically resumes
-- No option to disable permanently
-
-**Implementation notes**
-- Hook into `wp_head` for the meta tag and `send_headers` (or `wp_headers`) for the HTTP header
-- Store the disable expiry as a transient or option with a timestamp; check on each request
-- Settings UI should display the expiry time when disabled

--- a/includes/classes/Authentication/TwoFactor.php
+++ b/includes/classes/Authentication/TwoFactor.php
@@ -125,7 +125,7 @@ class TwoFactor {
 	/**
 	 * Restrict capabilities for non-SSO users without 2FA using map_meta_cap.
 	 *
-	 * Uses a whitelist approach: only allowed capabilities pass through,
+	 * Uses an allow-list approach: only allowed capabilities pass through,
 	 * everything else is blocked.
 	 *
 	 * @param array  $caps    The required primitive capabilities.
@@ -150,7 +150,7 @@ class TwoFactor {
 			return $caps;
 		}
 
-		// Only allow whitelisted capabilities, block everything else.
+		// Only allow listed capabilities, block everything else.
 		if ( ! in_array( $cap, self::ALLOWED_CAPABILITIES, true ) ) {
 			return [ 'do_not_allow' ];
 		}

--- a/includes/classes/Authors/Authors.php
+++ b/includes/classes/Authors/Authors.php
@@ -38,12 +38,12 @@ class Authors {
 		$author             = get_queried_object();
 		$current_domain     = wp_parse_url( get_site_url(), PHP_URL_HOST );
 
-		// Domain names that are whitelisted allowed to index 829 Studios users to be indexed
-		$whitelisted_domains = [];
+		// Domain names allowed to index 829 Studios users
+		$allowed_domains = [];
 
 		// Perform partial match on domains to catch subdomains or variation of domain name
 		$filtered_domains = array_filter(
-			$whitelisted_domains,
+			$allowed_domains,
 			function ( $domain ) use ( $current_domain ) {
 				return false !== stripos( $current_domain, $domain );
 			}

--- a/includes/classes/NoIndex/NoIndex.php
+++ b/includes/classes/NoIndex/NoIndex.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Force No-Index on staging and dev environments.
+ *
+ * @package  WordPressTools
+ */
+
+namespace WordPressTools\NoIndex;
+
+use WordPressTools\Singleton;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * NoIndex class
+ *
+ * Injects noindex meta tags and X-Robots-Tag headers on staging/dev domains
+ * or when WP_ENVIRONMENT_TYPE is not 'production'. Supports a timed disable
+ * (max 1 hour) configurable from the settings page.
+ */
+class NoIndex {
+
+	use Singleton;
+
+	const TRANSIENT_KEY       = 'wpt_noindex_disabled_until';
+	const MAX_DISABLE_SECONDS = 3600;
+
+	/**
+	 * Setup hooks.
+	 */
+	public function setup() {
+		if ( ! self::is_staging_or_dev() ) {
+			return;
+		}
+
+		add_filter( 'wp_robots',    [ $this, 'add_noindex_robots' ] );
+		add_action( 'send_headers', [ $this, 'send_noindex_header' ] );
+	}
+
+	/**
+	 * Return true when the current environment is staging or dev.
+	 *
+	 * Domain and TLD checks run first and override WP_ENVIRONMENT_TYPE, so a site
+	 * explicitly set to 'production' is still protected when its domain is a known
+	 * staging/dev domain or local TLD.
+	 *
+	 * @return bool
+	 */
+	public static function is_staging_or_dev(): bool {
+		$current_domain = strtolower( (string) wp_parse_url( site_url(), PHP_URL_HOST ) );
+
+		// Known staging/dev domain patterns — override WP_ENVIRONMENT_TYPE.
+		$staging_domains = [ '829dev.com', '829stage.com', 'pec-dev.com', 'pec-stage.com' ];
+		foreach ( $staging_domains as $domain ) {
+			$suffix = '.' . $domain;
+			if ( $current_domain === $domain || substr( $current_domain, -strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		// Local TLDs — override WP_ENVIRONMENT_TYPE.
+		$local_tlds = [ '.local', '.localhost', '.dev' ];
+		foreach ( $local_tlds as $tld ) {
+			if ( substr( $current_domain, -strlen( $tld ) ) === $tld ) {
+				return true;
+			}
+		}
+
+		// Fall back to WP_ENVIRONMENT_TYPE for any other non-production environment.
+		if ( defined( 'WP_ENVIRONMENT_TYPE' ) && 'production' !== WP_ENVIRONMENT_TYPE ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return true when enforcement is currently suspended via timed disable.
+	 *
+	 * @return bool
+	 */
+	public static function is_temporarily_disabled(): bool {
+		return self::get_disabled_until() > 0;
+	}
+
+	/**
+	 * Return the Unix timestamp when enforcement will resume, or 0 if active.
+	 *
+	 * @return int
+	 */
+	public static function get_disabled_until(): int {
+		$val = WPT_IS_NETWORK
+			? get_site_transient( self::TRANSIENT_KEY )
+			: get_transient( self::TRANSIENT_KEY );
+
+		if ( ! $val || time() >= (int) $val ) {
+			return 0;
+		}
+
+		return (int) $val;
+	}
+
+	/**
+	 * Suspend enforcement for a given number of seconds (capped at MAX_DISABLE_SECONDS).
+	 *
+	 * @param  int $duration_seconds Duration to suspend enforcement.
+	 * @return int                   Unix timestamp when enforcement will resume.
+	 */
+	public static function set_timed_disable( int $duration_seconds ): int {
+		$duration       = min( abs( $duration_seconds ), self::MAX_DISABLE_SECONDS );
+		$disabled_until = time() + $duration;
+
+		if ( WPT_IS_NETWORK ) {
+			set_site_transient( self::TRANSIENT_KEY, $disabled_until, $duration );
+		} else {
+			set_transient( self::TRANSIENT_KEY, $disabled_until, $duration );
+		}
+
+		return $disabled_until;
+	}
+
+	/**
+	 * Clear the timed disable and immediately resume enforcement.
+	 *
+	 * @return void
+	 */
+	public static function clear_timed_disable(): void {
+		if ( WPT_IS_NETWORK ) {
+			delete_site_transient( self::TRANSIENT_KEY );
+		} else {
+			delete_transient( self::TRANSIENT_KEY );
+		}
+	}
+
+	/**
+	 * Add noindex/nofollow directives to WordPress's robots meta tag.
+	 *
+	 * Hooks into wp_robots (WP 5.7+) so there is only ever one <meta name="robots"> tag.
+	 *
+	 * @param  array $robots Current robots directives.
+	 * @return array
+	 */
+	public function add_noindex_robots( array $robots ): array {
+		if ( self::is_temporarily_disabled() ) {
+			return $robots;
+		}
+		$robots['noindex']  = true;
+		$robots['nofollow'] = true;
+		return $robots;
+	}
+
+	/**
+	 * Send X-Robots-Tag HTTP header.
+	 *
+	 * @return void
+	 */
+	public function send_noindex_header(): void {
+		if ( self::is_temporarily_disabled() ) {
+			return;
+		}
+		header( 'X-Robots-Tag: noindex, nofollow' );
+	}
+}

--- a/includes/classes/NoIndex/NoIndex.php
+++ b/includes/classes/NoIndex/NoIndex.php
@@ -152,7 +152,7 @@ class NoIndex {
 	}
 
 	/**
-	 * Send X-Robots-Tag HTTP header.
+	 * Send X-Robots-Tag HTTP header on frontend requests only.
 	 *
 	 * @return void
 	 */
@@ -160,6 +160,12 @@ class NoIndex {
 		if ( self::is_temporarily_disabled() ) {
 			return;
 		}
+
+		// Skip admin screens, AJAX, and REST API endpoints.
+		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return;
+		}
+
 		header( 'X-Robots-Tag: noindex, nofollow' );
 	}
 }

--- a/includes/classes/PluginManagement/PluginManagement.php
+++ b/includes/classes/PluginManagement/PluginManagement.php
@@ -92,10 +92,10 @@ class PluginManagement {
 			return false;
 		}
 
-		$whitelist = ! empty( $settings['plugin_management_whitelist'] ) ? array_map( 'intval', (array) $settings['plugin_management_whitelist'] ) : [];
-		if ( ! empty( $whitelist ) ) {
+		$allow_list = ! empty( $settings['plugin_management_allow_list'] ) ? array_map( 'intval', (array) $settings['plugin_management_allow_list'] ) : [];
+		if ( ! empty( $allow_list ) ) {
 			$uid = $user_id ? (int) $user_id : get_current_user_id();
-			if ( in_array( $uid, $whitelist, true ) ) {
+			if ( in_array( $uid, $allow_list, true ) ) {
 				return false;
 			}
 		}
@@ -120,10 +120,10 @@ class PluginManagement {
 			return false;
 		}
 
-		$whitelist = ! empty( $settings['theme_management_whitelist'] ) ? array_map( 'intval', (array) $settings['theme_management_whitelist'] ) : [];
-		if ( ! empty( $whitelist ) ) {
+		$allow_list = ! empty( $settings['theme_management_allow_list'] ) ? array_map( 'intval', (array) $settings['theme_management_allow_list'] ) : [];
+		if ( ! empty( $allow_list ) ) {
 			$uid = $user_id ? (int) $user_id : get_current_user_id();
-			if ( in_array( $uid, $whitelist, true ) ) {
+			if ( in_array( $uid, $allow_list, true ) ) {
 				return false;
 			}
 		}
@@ -205,11 +205,11 @@ class PluginManagement {
 			return $caps;
 		}
 
-		$whitelist_key = $is_plugin_cap ? 'plugin_management_whitelist' : 'theme_management_whitelist';
-		$whitelist     = ! empty( $settings[ $whitelist_key ] ) ? array_map( 'intval', (array) $settings[ $whitelist_key ] ) : [];
+		$allow_list_key = $is_plugin_cap ? 'plugin_management_allow_list' : 'theme_management_allow_list';
+		$allow_list     = ! empty( $settings[ $allow_list_key ] ) ? array_map( 'intval', (array) $settings[ $allow_list_key ] ) : [];
 		$uid           = $user_id ? (int) $user_id : get_current_user_id();
 
-		if ( ! empty( $whitelist ) && in_array( $uid, $whitelist, true ) ) {
+		if ( ! empty( $allow_list ) && in_array( $uid, $allow_list, true ) ) {
 			return []; // Empty caps array grants access regardless of user role.
 		}
 

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -116,7 +116,7 @@ class SSO {
 		$redirect_to = filter_input( INPUT_GET, 'redirect_to' );
 
 		if ( empty( $redirect_to ) ) {
-			$redirect_to = home_url();
+			$redirect_to = admin_url();
 		}
 
 		$site_url  = home_url();

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -403,11 +403,11 @@ class SSO {
 			return $user;
 		}
 
-		$whitelist = ! empty( $settings['credential_login_whitelist'] )
-			? array_map( 'intval', (array) $settings['credential_login_whitelist'] )
+		$allow_list = ! empty( $settings['credential_login_allow_list'] )
+			? array_map( 'intval', (array) $settings['credential_login_allow_list'] )
 			: [];
 
-		if ( ! empty( $whitelist ) && in_array( (int) $user->ID, $whitelist, true ) ) {
+		if ( ! empty( $allow_list ) && in_array( (int) $user->ID, $allow_list, true ) ) {
 			return $user;
 		}
 

--- a/includes/classes/SSO/SSO.php
+++ b/includes/classes/SSO/SSO.php
@@ -33,6 +33,8 @@ class SSO {
 	 * Setup SSO
 	 */
 	public function __construct() {
+		// Always enforce domain-based credential restriction regardless of SSO state.
+		add_filter( 'authenticate', [ $this, 'block_829_domain_credential_login' ], 30 );
 
 		if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) {
 			return;
@@ -366,6 +368,53 @@ class SSO {
 			<?php endif; ?>
 		</style>
 		<?php
+	}
+
+	/**
+	 * Block credential login for @829llc.com and @829studios.com accounts.
+	 *
+	 * Runs at authenticate priority 30 (after core credential check at 20).
+	 * Fires regardless of SSO enabled/disabled state.
+	 *
+	 * @param WP_User|WP_Error|null $user Result from credential check.
+	 * @return WP_User|WP_Error
+	 */
+	public function block_829_domain_credential_login( $user ) {
+		if ( is_wp_error( $user ) || ! ( $user instanceof \WP_User ) ) {
+			return $user;
+		}
+
+		// When SSO itself is disabled there is no alternative login path, so
+		// enforcing the credential restriction would permanently lock 829 users out.
+		if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) {
+			return $user;
+		}
+
+		$settings = Settings::get_settings();
+
+		if ( empty( $settings['restrict_829_credential_login'] ) ) {
+			return $user;
+		}
+
+		$restricted_domains = [ '829llc.com', '829studios.com' ];
+		$email_domain       = strtolower( substr( strrchr( $user->user_email, '@' ), 1 ) );
+
+		if ( ! in_array( $email_domain, $restricted_domains, true ) ) {
+			return $user;
+		}
+
+		$whitelist = ! empty( $settings['credential_login_whitelist'] )
+			? array_map( 'intval', (array) $settings['credential_login_whitelist'] )
+			: [];
+
+		if ( ! empty( $whitelist ) && in_array( (int) $user->ID, $whitelist, true ) ) {
+			return $user;
+		}
+
+		return new WP_Error(
+			'wpt-829-domain-login',
+			esc_html__( 'Users with @829llc.com or @829studios.com email addresses must sign in using Okta.', 'wordpress-tools' )
+		);
 	}
 
 	/**

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -51,14 +51,14 @@ class Settings {
 		$defaults = [
 			'allow_sso'                      => 1,
 			'restrict_829_credential_login'  => 1,
-			'credential_login_whitelist'     => [],
+			'credential_login_allow_list'     => [],
 			'disable_comments'               => 0,
 			'require_strong_passwords'       => 1,
 			'password_protect'               => 0,
 			'restrict_plugin_management'     => 1,
-			'plugin_management_whitelist'    => [],
+			'plugin_management_allow_list'    => [],
 			'restrict_theme_management'      => 1,
-			'theme_management_whitelist'     => [],
+			'theme_management_allow_list'     => [],
 			'restrict_rest_api'              => 'users',
 			'limit_login'                    => 1,
 			'enable_mcp'                     => 1,
@@ -69,6 +69,28 @@ class Settings {
 			$settings = get_site_option( 'wpt_settings', [] );
 		} else {
 			$settings = get_option( 'wpt_settings', [] );
+		}
+
+		// One-time migration: rename legacy *_whitelist keys to *_allow_list.
+		$legacy_keys = [
+			'credential_login_whitelist'  => 'credential_login_allow_list',
+			'plugin_management_whitelist' => 'plugin_management_allow_list',
+			'theme_management_whitelist'  => 'theme_management_allow_list',
+		];
+		$migrated = false;
+		foreach ( $legacy_keys as $old => $new ) {
+			if ( array_key_exists( $old, $settings ) ) {
+				$settings[ $new ] = $settings[ $old ];
+				unset( $settings[ $old ] );
+				$migrated = true;
+			}
+		}
+		if ( $migrated ) {
+			if ( WPT_IS_NETWORK ) {
+				update_site_option( 'wpt_settings', $settings );
+			} else {
+				update_option( 'wpt_settings', $settings );
+			}
 		}
 
 		// Merge with defaults to ensure all keys exist
@@ -183,14 +205,14 @@ class Settings {
 				'default'           => [
 					'allow_sso'                     => 1,
 					'restrict_829_credential_login' => 1,
-					'credential_login_whitelist'    => [],
+					'credential_login_allow_list'    => [],
 					'disable_comments'              => 0,
 					'require_strong_passwords'      => 1,
 					'password_protect'              => 0,
 					'restrict_plugin_management'    => 1,
-					'plugin_management_whitelist'   => [],
+					'plugin_management_allow_list'   => [],
 					'restrict_theme_management'     => 1,
-					'theme_management_whitelist'    => [],
+					'theme_management_allow_list'    => [],
 					'restrict_rest_api'             => 'users',
 					'limit_login'                   => 1,
 					'enable_mcp'                    => 1,
@@ -340,17 +362,17 @@ class Settings {
 	public function restrict_829_credential_login_setting_callback() {
 		$settings  = self::get_settings();
 		$restrict  = $settings['restrict_829_credential_login'];
-		$whitelist = $settings['credential_login_whitelist'] ?? [];
-		$this->render_credential_login_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['credential_login_allow_list'] ?? [];
+		$this->render_credential_login_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict 829 Credential Login setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_credential_login_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_credential_login_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-829-credential-login-yes" name="wpt_settings[restrict_829_credential_login]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -367,10 +389,10 @@ class Settings {
 				<p class="description" style="color:#d63638;margin-top:4px;"><?php esc_html_e( 'Warning: SSO is currently disabled (WPT_SSO_DISABLE). This restriction will not be enforced until SSO is re-enabled, to prevent lockout.', 'wordpress-tools' ); ?></p>
 			<?php endif; ?>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Credential Login Exceptions', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can still log in with credentials even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'credential_login_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'credential_login_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -379,7 +401,7 @@ class Settings {
 	/**
 	 * Render a user search field with tag-style selected users.
 	 *
-	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param string $setting_key Settings key for the allow list array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
 	protected function render_user_search_field( $setting_key, $user_ids ) {
@@ -473,17 +495,17 @@ class Settings {
 	public function restrict_plugin_management_setting_callback() {
 		$settings = self::get_settings();
 		$restrict  = $settings['restrict_plugin_management'];
-		$whitelist = $settings['plugin_management_whitelist'] ?? [];
-		$this->render_plugin_management_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['plugin_management_allow_list'] ?? [];
+		$this->render_plugin_management_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict Plugin Management setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_plugin_management_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_plugin_management_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -497,10 +519,10 @@ class Settings {
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
-				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Allowed Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'plugin_management_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'plugin_management_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -512,17 +534,17 @@ class Settings {
 	public function restrict_theme_management_setting_callback() {
 		$settings  = self::get_settings();
 		$restrict  = $settings['restrict_theme_management'];
-		$whitelist = $settings['theme_management_whitelist'] ?? [];
-		$this->render_theme_management_restriction_field( $restrict, $whitelist );
+		$allow_list = $settings['theme_management_allow_list'] ?? [];
+		$this->render_theme_management_restriction_field( $restrict, $allow_list);
 	}
 
 	/**
 	 * Shared fieldset for the Restrict Theme Management setting.
 	 *
 	 * @param int   $restrict  1 if restriction is enabled.
-	 * @param array $whitelist Currently saved user IDs.
+	 * @param array $allow_list Currently saved user IDs.
 	 */
-	private function render_theme_management_restriction_field( int $restrict, array $whitelist ): void {
+	private function render_theme_management_restriction_field( int $restrict, array $allow_list ): void {
 		?>
 		<fieldset>
 			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
@@ -536,10 +558,10 @@ class Settings {
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
-				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
+			<div class="wpt-allow-list-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Allowed Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-				<?php $this->render_user_search_field( 'theme_management_whitelist', $whitelist ); ?>
+				<?php $this->render_user_search_field( 'theme_management_allow_list', $allow_list); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -548,7 +570,7 @@ class Settings {
 	/**
 	 * Render a user search field with tag-style selected users.
 	 *
-	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param string $setting_key Settings key for the allow list array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
 	/**
@@ -771,9 +793,9 @@ class Settings {
 		// Sanitize restrict_829_credential_login (defaults to 1/on when missing)
 		$sanitized['restrict_829_credential_login'] = isset( $input['restrict_829_credential_login'] ) ? intval( $input['restrict_829_credential_login'] ) : 1;
 
-		// Sanitize credential_login_whitelist — drops IDs for deleted users
-		$sanitized['credential_login_whitelist'] = isset( $input['credential_login_whitelist'] )
-			? $this->sanitize_user_id_list( $input['credential_login_whitelist'] )
+		// Sanitize credential_login_allow_list — drops IDs for deleted users
+		$sanitized['credential_login_allow_list'] = isset( $input['credential_login_allow_list'] )
+			? $this->sanitize_user_id_list( $input['credential_login_allow_list'] )
 			: [];
 
 		// Sanitize disable_comments
@@ -788,17 +810,17 @@ class Settings {
 		// Sanitize restrict_plugin_management
 		$sanitized['restrict_plugin_management'] = isset( $input['restrict_plugin_management'] ) ? intval( $input['restrict_plugin_management'] ) : 0;
 
-		// Sanitize plugin_management_whitelist — drops IDs for deleted users
-		$sanitized['plugin_management_whitelist'] = isset( $input['plugin_management_whitelist'] )
-			? $this->sanitize_user_id_list( $input['plugin_management_whitelist'] )
+		// Sanitize plugin_management_allow_list — drops IDs for deleted users
+		$sanitized['plugin_management_allow_list'] = isset( $input['plugin_management_allow_list'] )
+			? $this->sanitize_user_id_list( $input['plugin_management_allow_list'] )
 			: [];
 
 		// Sanitize restrict_theme_management
 		$sanitized['restrict_theme_management'] = isset( $input['restrict_theme_management'] ) ? intval( $input['restrict_theme_management'] ) : 0;
 
-		// Sanitize theme_management_whitelist — drops IDs for deleted users
-		$sanitized['theme_management_whitelist'] = isset( $input['theme_management_whitelist'] )
-			? $this->sanitize_user_id_list( $input['theme_management_whitelist'] )
+		// Sanitize theme_management_allow_list — drops IDs for deleted users
+		$sanitized['theme_management_allow_list'] = isset( $input['theme_management_allow_list'] )
+			? $this->sanitize_user_id_list( $input['theme_management_allow_list'] )
 			: [];
 
 		// Sanitize restrict_rest_api
@@ -973,14 +995,14 @@ class Settings {
 		$settings                        = self::get_settings();
 		$allow_sso                       = $settings['allow_sso'];
 		$restrict_829_credential_login   = $settings['restrict_829_credential_login'];
-		$credential_login_whitelist      = isset( $settings['credential_login_whitelist'] ) ? $settings['credential_login_whitelist'] : [];
+		$credential_login_allow_list      = isset( $settings['credential_login_allow_list'] ) ? $settings['credential_login_allow_list'] : [];
 		$disable_comments                = $settings['disable_comments'];
 		$require_strong_passwords        = $settings['require_strong_passwords'];
 		$password_protect                = $settings['password_protect'];
 		$restrict_plugin_management      = $settings['restrict_plugin_management'];
-		$plugin_management_whitelist     = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$plugin_management_allow_list     = isset( $settings['plugin_management_allow_list'] ) ? $settings['plugin_management_allow_list'] : [];
 		$restrict_theme_management       = $settings['restrict_theme_management'];
-		$theme_management_whitelist      = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$theme_management_allow_list      = isset( $settings['theme_management_allow_list'] ) ? $settings['theme_management_allow_list'] : [];
 		$restrict_rest_api               = $settings['restrict_rest_api'];
 		$limit_login                     = $settings['limit_login'];
 		$enable_mcp                      = $settings['enable_mcp'];
@@ -1030,7 +1052,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict 829 Credential Login', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_whitelist ); ?>
+								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1090,7 +1112,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Plugin Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_whitelist ); ?>
+								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1098,7 +1120,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Theme Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_whitelist ); ?>
+								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_allow_list ); ?>
 							</td>
 						</tr>
 						<tr>

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -8,6 +8,7 @@
 namespace WordPressTools\Settings;
 
 use WordPressTools\Singleton;
+use WordPressTools\NoIndex\NoIndex;
 use function WordPressTools\Utils\is_local_environment;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -39,6 +40,8 @@ class Settings {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_settings_assets' ] );
 		add_action( 'network_admin_enqueue_scripts', [ $this, 'enqueue_settings_assets' ] );
 		add_action( 'wp_ajax_wpt_search_users', [ $this, 'ajax_search_users' ] );
+		add_action( 'wp_ajax_wpt_noindex_disable', [ $this, 'ajax_noindex_disable' ] );
+		add_action( 'wp_ajax_wpt_noindex_enable', [ $this, 'ajax_noindex_enable' ] );
 	}
 
 	/**
@@ -313,6 +316,15 @@ class Settings {
 			'wpt_enable_mcp',
 			esc_html__( 'Enable MCP', 'wordpress-tools' ),
 			[ $this, 'mcp_setting_callback' ],
+			'wpt-829-settings',
+			'wpt_829_general_section'
+		);
+
+		// Force No-Index on Staging/Dev setting field
+		add_settings_field(
+			'wpt_noindex_status',
+			esc_html__( 'Force No-Index on Staging/Dev', 'wordpress-tools' ),
+			[ $this, 'noindex_status_setting_callback' ],
 			'wpt-829-settings',
 			'wpt_829_general_section'
 		);
@@ -669,6 +681,109 @@ class Settings {
 	}
 
 	/**
+	 * Force No-Index on Staging/Dev setting callback.
+	 */
+	public function noindex_status_setting_callback() {
+		$this->render_noindex_status_field();
+	}
+
+	/**
+	 * Shared fieldset for the Force No-Index status setting.
+	 */
+	private function render_noindex_status_field(): void {
+		$is_applicable  = NoIndex::is_staging_or_dev();
+		$disabled_until = $is_applicable ? NoIndex::get_disabled_until() : 0;
+		$is_disabled    = $disabled_until > 0;
+		?>
+		<fieldset>
+			<?php if ( ! $is_applicable ) : ?>
+				<p class="description"><?php esc_html_e( 'Not applicable — this site is running in a production environment.', 'wordpress-tools' ); ?></p>
+			<?php elseif ( $is_disabled ) : ?>
+				<?php
+				$remaining_seconds = max( 0, $disabled_until - time() );
+				$remaining_minutes = (int) ceil( $remaining_seconds / 60 );
+				?>
+				<p><span class="wpt-status-badge wpt-status-disabled"><?php esc_html_e( 'Temporarily Disabled', 'wordpress-tools' ); ?></span></p>
+				<p class="description">
+					<?php
+					echo wp_kses(
+						sprintf(
+							/* translators: %s: number of minutes remaining */
+							_n(
+								'noindex enforcement is suspended. Resumes in %s minute.',
+								'noindex enforcement is suspended. Resumes in %s minutes.',
+								$remaining_minutes,
+								'wordpress-tools'
+							),
+							'<strong>' . esc_html( $remaining_minutes ) . '</strong>'
+						),
+						[ 'strong' => [] ]
+					);
+					?>
+				</p>
+				<button type="button" id="wpt-noindex-enable-btn" class="button button-secondary"
+					data-label="<?php esc_attr_e( 'Re-enable now', 'wordpress-tools' ); ?>"
+					data-loading="<?php esc_attr_e( 'Re-enabling…', 'wordpress-tools' ); ?>">
+					<?php esc_html_e( 'Re-enable now', 'wordpress-tools' ); ?>
+				</button>
+			<?php else : ?>
+				<p><span class="wpt-status-badge wpt-status-active"><?php esc_html_e( 'Active', 'wordpress-tools' ); ?></span></p>
+				<p class="description"><?php esc_html_e( 'noindex, nofollow is being injected on all frontend requests to this environment.', 'wordpress-tools' ); ?></p>
+				<p style="margin-top:8px;display:flex;align-items:center;gap:6px;">
+					<select id="wpt-noindex-duration">
+						<option value="300"><?php esc_html_e( '5 minutes', 'wordpress-tools' ); ?></option>
+						<option value="900"><?php esc_html_e( '15 minutes', 'wordpress-tools' ); ?></option>
+						<option value="1800"><?php esc_html_e( '30 minutes', 'wordpress-tools' ); ?></option>
+						<option value="3600"><?php esc_html_e( '1 hour', 'wordpress-tools' ); ?></option>
+					</select>
+					<button type="button" id="wpt-noindex-disable-btn" class="button button-secondary"
+						data-label="<?php esc_attr_e( 'Temporarily Disable', 'wordpress-tools' ); ?>"
+						data-loading="<?php esc_attr_e( 'Disabling…', 'wordpress-tools' ); ?>">
+						<?php esc_html_e( 'Temporarily Disable', 'wordpress-tools' ); ?>
+					</button>
+				</p>
+			<?php endif; ?>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * AJAX handler: temporarily disable noindex enforcement.
+	 */
+	public function ajax_noindex_disable() {
+		check_ajax_referer( 'wpt_noindex_toggle', 'nonce' );
+
+		if ( ! $this->can_access_settings() ) {
+			wp_send_json_error( 'Unauthorized' );
+			return;
+		}
+
+		$allowed_durations = [ 300, 900, 1800, 3600 ];
+		$duration          = isset( $_POST['duration'] ) ? intval( $_POST['duration'] ) : 300;
+		if ( ! in_array( $duration, $allowed_durations, true ) ) {
+			$duration = 300;
+		}
+
+		$disabled_until = NoIndex::set_timed_disable( $duration );
+		wp_send_json_success( [ 'disabled_until' => $disabled_until ] );
+	}
+
+	/**
+	 * AJAX handler: re-enable noindex enforcement immediately.
+	 */
+	public function ajax_noindex_enable() {
+		check_ajax_referer( 'wpt_noindex_toggle', 'nonce' );
+
+		if ( ! $this->can_access_settings() ) {
+			wp_send_json_error( 'Unauthorized' );
+			return;
+		}
+
+		NoIndex::clear_timed_disable();
+		wp_send_json_success();
+	}
+
+	/**
 	 * API Key setting callback.
 	 */
 	public function api_key_setting_callback() {
@@ -871,6 +986,23 @@ class Settings {
 				'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
 				'nonce'       => wp_create_nonce( 'wpt_search_users' ),
 				'removeLabel' => __( 'Remove', 'wordpress-tools' ),
+			]
+		);
+
+		wp_enqueue_script(
+			'wpt-settings-noindex',
+			WPT_PLUGIN_URL . 'assets/js/settings-noindex.js',
+			[],
+			file_exists( WPT_PLUGIN_DIR . 'assets/js/settings-noindex.js' ) ? filemtime( WPT_PLUGIN_DIR . 'assets/js/settings-noindex.js' ) : WPT_VERSION,
+			true
+		);
+
+		wp_localize_script(
+			'wpt-settings-noindex',
+			'wptNoIndex',
+			[
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'wpt_noindex_toggle' ),
 			]
 		);
 	}
@@ -1205,6 +1337,14 @@ class Settings {
 									</label>
 									<p class="description"><?php esc_html_e( 'Exposes site management tools (plugins, themes, users, system info) via the WordPress MCP Adapter.', 'wordpress-tools' ); ?></p>
 								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<?php esc_html_e( 'Force No-Index on Staging/Dev', 'wordpress-tools' ); ?>
+							</th>
+							<td>
+								<?php $this->render_noindex_status_field(); ?>
 							</td>
 						</tr>
 						<tr>

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -754,7 +754,7 @@ class Settings {
 		check_ajax_referer( 'wpt_noindex_toggle', 'nonce' );
 
 		if ( ! $this->can_access_settings() ) {
-			wp_send_json_error( 'Unauthorized' );
+			wp_send_json_error( esc_html__( 'Unauthorized.', 'wordpress-tools' ), 403 );
 			return;
 		}
 
@@ -775,7 +775,7 @@ class Settings {
 		check_ajax_referer( 'wpt_noindex_toggle', 'nonce' );
 
 		if ( ! $this->can_access_settings() ) {
-			wp_send_json_error( 'Unauthorized' );
+			wp_send_json_error( esc_html__( 'Unauthorized.', 'wordpress-tools' ), 403 );
 			return;
 		}
 

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -49,17 +49,19 @@ class Settings {
 	 */
 	public static function get_settings() {
 		$defaults = [
-			'allow_sso'                    => 1,
-			'disable_comments'             => 0,
-			'require_strong_passwords'     => 1,
-			'password_protect'             => 0,
-			'restrict_plugin_management'   => 1,
-			'plugin_management_whitelist'  => [],
-			'restrict_theme_management'    => 1,
-			'theme_management_whitelist'   => [],
-			'restrict_rest_api'            => 'users',
-			'limit_login'                  => 1,
-			'enable_mcp'                   => 1,
+			'allow_sso'                      => 1,
+			'restrict_829_credential_login'  => 1,
+			'credential_login_whitelist'     => [],
+			'disable_comments'               => 0,
+			'require_strong_passwords'       => 1,
+			'password_protect'               => 0,
+			'restrict_plugin_management'     => 1,
+			'plugin_management_whitelist'    => [],
+			'restrict_theme_management'      => 1,
+			'theme_management_whitelist'     => [],
+			'restrict_rest_api'              => 'users',
+			'limit_login'                    => 1,
+			'enable_mcp'                     => 1,
 		];
 
 		// Get settings from single option
@@ -179,17 +181,19 @@ class Settings {
 				'type'              => 'array',
 				'sanitize_callback' => [ $this, 'sanitize_settings' ],
 				'default'           => [
-					'allow_sso'                   => 1,
-					'disable_comments'            => 0,
-					'require_strong_passwords'    => 1,
-					'password_protect'            => 0,
-					'restrict_plugin_management'  => 0,
-					'plugin_management_whitelist' => [],
-					'restrict_theme_management'   => 0,
-					'theme_management_whitelist'  => [],
-					'restrict_rest_api'           => 'users',
-					'limit_login'                 => 1,
-					'enable_mcp'                  => 1,
+					'allow_sso'                     => 1,
+					'restrict_829_credential_login' => 1,
+					'credential_login_whitelist'    => [],
+					'disable_comments'              => 0,
+					'require_strong_passwords'      => 1,
+					'password_protect'              => 0,
+					'restrict_plugin_management'    => 1,
+					'plugin_management_whitelist'   => [],
+					'restrict_theme_management'     => 1,
+					'theme_management_whitelist'    => [],
+					'restrict_rest_api'             => 'users',
+					'limit_login'                   => 1,
+					'enable_mcp'                    => 1,
 				],
 			]
 		);
@@ -206,6 +210,15 @@ class Settings {
 			'wpt_allow_sso',
 			esc_html__( 'Allow 829 Studios SSO', 'wordpress-tools' ),
 			[ $this, 'sso_setting_callback' ],
+			'wpt-829-settings',
+			'wpt_829_general_section'
+		);
+
+		// Restrict 829 Credential Login setting field
+		add_settings_field(
+			'wpt_restrict_829_credential_login',
+			esc_html__( 'Restrict 829 Credential Login', 'wordpress-tools' ),
+			[ $this, 'restrict_829_credential_login_setting_callback' ],
 			'wpt-829-settings',
 			'wpt_829_general_section'
 		);
@@ -322,6 +335,77 @@ class Settings {
 	}
 
 	/**
+	 * Restrict 829 Credential Login setting callback.
+	 */
+	public function restrict_829_credential_login_setting_callback() {
+		$settings  = self::get_settings();
+		$restrict  = $settings['restrict_829_credential_login'];
+		$whitelist = $settings['credential_login_whitelist'] ?? [];
+		$this->render_credential_login_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict 829 Credential Login setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_credential_login_restriction_field( int $restrict, array $whitelist ): void {
+		?>
+		<fieldset>
+			<input id="wpt-restrict-829-credential-login-yes" name="wpt_settings[restrict_829_credential_login]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
+			<label for="wpt-restrict-829-credential-login-yes">
+				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
+			</label><br>
+
+			<input id="wpt-restrict-829-credential-login-no" name="wpt_settings[restrict_829_credential_login]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
+			<label for="wpt-restrict-829-credential-login-no">
+				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
+			</label>
+			<p class="description"><?php esc_html_e( 'Prevents users with @829llc.com or @829studios.com email addresses from logging in with username/password. They must use Okta SSO.', 'wordpress-tools' ); ?></p>
+			<?php if ( defined( 'WPT_SSO_DISABLE' ) && WPT_SSO_DISABLE ) : ?>
+				<p class="description" style="color:#d63638;margin-top:4px;"><?php esc_html_e( 'Warning: SSO is currently disabled (WPT_SSO_DISABLE). This restriction will not be enforced until SSO is re-enabled, to prevent lockout.', 'wordpress-tools' ); ?></p>
+			<?php endif; ?>
+
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_829_credential_login">
+				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Credential Login Exceptions', 'wordpress-tools' ); ?></strong></p>
+				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can still log in with credentials even when restriction is enabled.', 'wordpress-tools' ); ?></p>
+				<?php $this->render_user_search_field( 'credential_login_whitelist', $whitelist ); ?>
+			</div>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Render a user search field with tag-style selected users.
+	 *
+	 * @param string $setting_key Settings key for the whitelist array.
+	 * @param array  $user_ids    Currently saved user IDs.
+	 */
+	protected function render_user_search_field( $setting_key, $user_ids ) {
+		$user_ids = array_filter( array_map( 'intval', (array) $user_ids ) );
+		$users    = ! empty( $user_ids ) ? get_users( [ 'include' => $user_ids ] ) : [];
+		?>
+		<div class="wpt-user-search" data-setting-key="<?php echo esc_attr( $setting_key ); ?>">
+			<div class="wpt-user-tags">
+				<?php foreach ( $users as $user ) : ?>
+					<span class="wpt-user-tag">
+						<span class="wpt-user-tag-label"><?php echo esc_html( $user->display_name . ' (' . $user->user_email . ')' ); ?></span>
+						<button type="button" class="wpt-user-tag-remove" data-user-id="<?php echo esc_attr( $user->ID ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Remove %s', 'wordpress-tools' ), $user->display_name ) ); ?>">&times;</button>
+					</span>
+				<?php endforeach; ?>
+			</div>
+			<div class="wpt-user-ids">
+				<?php foreach ( $user_ids as $uid ) : ?>
+					<input type="hidden" name="wpt_settings[<?php echo esc_attr( $setting_key ); ?>][]" value="<?php echo esc_attr( $uid ); ?>" />
+				<?php endforeach; ?>
+			</div>
+			<input type="text" class="wpt-user-search-input regular-text" placeholder="<?php esc_attr_e( 'Search users…', 'wordpress-tools' ); ?>" autocomplete="off" />
+		</div>
+		<?php
+	}
+
+	/**
 	 * Comments setting callback.
 	 */
 	public function comments_setting_callback() {
@@ -387,23 +471,33 @@ class Settings {
 	 * Restrict Plugin Management setting callback.
 	 */
 	public function restrict_plugin_management_setting_callback() {
-		$settings                   = self::get_settings();
-		$restrict_plugin_management = $settings['restrict_plugin_management'];
-		$whitelist                  = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$settings = self::get_settings();
+		$restrict  = $settings['restrict_plugin_management'];
+		$whitelist = $settings['plugin_management_whitelist'] ?? [];
+		$this->render_plugin_management_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict Plugin Management setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_plugin_management_restriction_field( int $restrict, array $whitelist ): void {
 		?>
 		<fieldset>
-			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict_plugin_management ); ?> />
+			<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
 			<label for="wpt-restrict-plugin-management-yes">
 				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
 			</label><br>
 
-			<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict_plugin_management ); ?> />
+			<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
 			<label for="wpt-restrict-plugin-management-no">
 				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container" data-restriction="restrict_plugin_management"<?php echo $restrict_plugin_management ? '' : ' style="display:none"'; ?>>
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_plugin_management">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
 				<?php $this->render_user_search_field( 'plugin_management_whitelist', $whitelist ); ?>
@@ -416,23 +510,33 @@ class Settings {
 	 * Restrict Theme Management setting callback.
 	 */
 	public function restrict_theme_management_setting_callback() {
-		$settings                  = self::get_settings();
-		$restrict_theme_management = $settings['restrict_theme_management'];
-		$whitelist                 = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$settings  = self::get_settings();
+		$restrict  = $settings['restrict_theme_management'];
+		$whitelist = $settings['theme_management_whitelist'] ?? [];
+		$this->render_theme_management_restriction_field( $restrict, $whitelist );
+	}
+
+	/**
+	 * Shared fieldset for the Restrict Theme Management setting.
+	 *
+	 * @param int   $restrict  1 if restriction is enabled.
+	 * @param array $whitelist Currently saved user IDs.
+	 */
+	private function render_theme_management_restriction_field( int $restrict, array $whitelist ): void {
 		?>
 		<fieldset>
-			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict_theme_management ); ?> />
+			<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict ); ?> />
 			<label for="wpt-restrict-theme-management-yes">
 				<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
 			</label><br>
 
-			<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict_theme_management ); ?> />
+			<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict ); ?> />
 			<label for="wpt-restrict-theme-management-no">
 				<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
 			</label>
 			<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
 
-			<div class="wpt-whitelist-container" data-restriction="restrict_theme_management"<?php echo $restrict_theme_management ? '' : ' style="display:none"'; ?>>
+			<div class="wpt-whitelist-container<?php echo $restrict ? '' : ' wpt-hidden'; ?>" data-restriction="restrict_theme_management">
 				<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
 				<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
 				<?php $this->render_user_search_field( 'theme_management_whitelist', $whitelist ); ?>
@@ -447,29 +551,6 @@ class Settings {
 	 * @param string $setting_key Settings key for the whitelist array.
 	 * @param array  $user_ids    Currently saved user IDs.
 	 */
-	protected function render_user_search_field( $setting_key, $user_ids ) {
-		$user_ids = array_filter( array_map( 'intval', (array) $user_ids ) );
-		$users    = ! empty( $user_ids ) ? get_users( [ 'include' => $user_ids ] ) : [];
-		?>
-		<div class="wpt-user-search" data-setting-key="<?php echo esc_attr( $setting_key ); ?>">
-			<div class="wpt-user-tags">
-				<?php foreach ( $users as $user ) : ?>
-					<span class="wpt-user-tag">
-						<span class="wpt-user-tag-label"><?php echo esc_html( $user->display_name . ' (' . $user->user_email . ')' ); ?></span>
-						<button type="button" class="wpt-user-tag-remove" data-user-id="<?php echo esc_attr( $user->ID ); ?>" aria-label="<?php echo esc_attr( sprintf( __( 'Remove %s', 'wordpress-tools' ), $user->display_name ) ); ?>">&times;</button>
-					</span>
-				<?php endforeach; ?>
-			</div>
-			<div class="wpt-user-ids">
-				<?php foreach ( $user_ids as $uid ) : ?>
-					<input type="hidden" name="wpt_settings[<?php echo esc_attr( $setting_key ); ?>][]" value="<?php echo esc_attr( $uid ); ?>" />
-				<?php endforeach; ?>
-			</div>
-			<input type="text" class="wpt-user-search-input regular-text" placeholder="<?php esc_attr_e( 'Search users…', 'wordpress-tools' ); ?>" autocomplete="off" />
-		</div>
-		<?php
-	}
-
 	/**
 	 * REST API Restriction setting callback.
 	 */
@@ -661,6 +742,21 @@ class Settings {
 	}
 
 	/**
+	 * Convert a raw list of user IDs to a clean array of ints, dropping any
+	 * IDs that no longer correspond to an existing WordPress user.
+	 *
+	 * @param  mixed $ids Raw value from form input.
+	 * @return array      Validated, re-indexed array of user IDs.
+	 */
+	private function sanitize_user_id_list( $ids ): array {
+		$ids = array_values( array_filter( array_map( 'intval', (array) $ids ) ) );
+		if ( empty( $ids ) ) {
+			return [];
+		}
+		return array_map( 'intval', get_users( [ 'include' => $ids, 'fields' => 'ID', 'number' => count( $ids ) ] ) );
+	}
+
+	/**
 	 * Sanitize all settings.
 	 *
 	 * @param  array $input Raw input values.
@@ -671,6 +767,14 @@ class Settings {
 
 		// Sanitize allow_sso
 		$sanitized['allow_sso'] = isset( $input['allow_sso'] ) ? intval( $input['allow_sso'] ) : 1;
+
+		// Sanitize restrict_829_credential_login (defaults to 1/on when missing)
+		$sanitized['restrict_829_credential_login'] = isset( $input['restrict_829_credential_login'] ) ? intval( $input['restrict_829_credential_login'] ) : 1;
+
+		// Sanitize credential_login_whitelist — drops IDs for deleted users
+		$sanitized['credential_login_whitelist'] = isset( $input['credential_login_whitelist'] )
+			? $this->sanitize_user_id_list( $input['credential_login_whitelist'] )
+			: [];
 
 		// Sanitize disable_comments
 		$sanitized['disable_comments'] = isset( $input['disable_comments'] ) ? intval( $input['disable_comments'] ) : 0;
@@ -684,17 +788,17 @@ class Settings {
 		// Sanitize restrict_plugin_management
 		$sanitized['restrict_plugin_management'] = isset( $input['restrict_plugin_management'] ) ? intval( $input['restrict_plugin_management'] ) : 0;
 
-		// Sanitize plugin_management_whitelist
+		// Sanitize plugin_management_whitelist — drops IDs for deleted users
 		$sanitized['plugin_management_whitelist'] = isset( $input['plugin_management_whitelist'] )
-			? array_values( array_filter( array_map( 'intval', (array) $input['plugin_management_whitelist'] ) ) )
+			? $this->sanitize_user_id_list( $input['plugin_management_whitelist'] )
 			: [];
 
 		// Sanitize restrict_theme_management
 		$sanitized['restrict_theme_management'] = isset( $input['restrict_theme_management'] ) ? intval( $input['restrict_theme_management'] ) : 0;
 
-		// Sanitize theme_management_whitelist
+		// Sanitize theme_management_whitelist — drops IDs for deleted users
 		$sanitized['theme_management_whitelist'] = isset( $input['theme_management_whitelist'] )
-			? array_values( array_filter( array_map( 'intval', (array) $input['theme_management_whitelist'] ) ) )
+			? $this->sanitize_user_id_list( $input['theme_management_whitelist'] )
 			: [];
 
 		// Sanitize restrict_rest_api
@@ -866,18 +970,20 @@ class Settings {
 			wp_die( esc_html__( 'You do not have permission to access this page.', 'wordpress-tools' ) );
 		}
 
-		$settings                    = self::get_settings();
-		$allow_sso                   = $settings['allow_sso'];
-		$disable_comments            = $settings['disable_comments'];
-		$require_strong_passwords    = $settings['require_strong_passwords'];
-		$password_protect            = $settings['password_protect'];
-		$restrict_plugin_management  = $settings['restrict_plugin_management'];
-		$plugin_management_whitelist = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
-		$restrict_theme_management   = $settings['restrict_theme_management'];
-		$theme_management_whitelist  = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
-		$restrict_rest_api           = $settings['restrict_rest_api'];
-		$limit_login                = $settings['limit_login'];
-		$enable_mcp                 = $settings['enable_mcp'];
+		$settings                        = self::get_settings();
+		$allow_sso                       = $settings['allow_sso'];
+		$restrict_829_credential_login   = $settings['restrict_829_credential_login'];
+		$credential_login_whitelist      = isset( $settings['credential_login_whitelist'] ) ? $settings['credential_login_whitelist'] : [];
+		$disable_comments                = $settings['disable_comments'];
+		$require_strong_passwords        = $settings['require_strong_passwords'];
+		$password_protect                = $settings['password_protect'];
+		$restrict_plugin_management      = $settings['restrict_plugin_management'];
+		$plugin_management_whitelist     = isset( $settings['plugin_management_whitelist'] ) ? $settings['plugin_management_whitelist'] : [];
+		$restrict_theme_management       = $settings['restrict_theme_management'];
+		$theme_management_whitelist      = isset( $settings['theme_management_whitelist'] ) ? $settings['theme_management_whitelist'] : [];
+		$restrict_rest_api               = $settings['restrict_rest_api'];
+		$limit_login                     = $settings['limit_login'];
+		$enable_mcp                      = $settings['enable_mcp'];
 		$attempt_limit              = defined( 'WPT_LOGIN_ATTEMPT_LIMIT' ) ? WPT_LOGIN_ATTEMPT_LIMIT : 10;
 		$lockout_minutes            = defined( 'WPT_LOGIN_LOCKOUT_DURATION' ) ? ceil( WPT_LOGIN_LOCKOUT_DURATION / 60 ) : 15;
 		$is_disabled                = defined( 'WPT_DISABLE_COMMENTS' ) || has_filter( 'wpt_disable_comments' );
@@ -917,6 +1023,14 @@ class Settings {
 									</label>
 									<p class="description"><?php esc_html_e( 'This allows members of 829 Studios to log in via SSO. This is extremely important to streamline maintenance of your website.', 'wordpress-tools' ); ?></p>
 								</fieldset>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<?php esc_html_e( 'Restrict 829 Credential Login', 'wordpress-tools' ); ?>
+							</th>
+							<td>
+								<?php $this->render_credential_login_restriction_field( $restrict_829_credential_login, $credential_login_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -976,24 +1090,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Plugin Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<fieldset>
-									<input id="wpt-restrict-plugin-management-yes" name="wpt_settings[restrict_plugin_management]" type="radio" value="1"<?php checked( 1, $restrict_plugin_management ); ?> />
-									<label for="wpt-restrict-plugin-management-yes">
-										<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
-									</label><br>
-
-									<input id="wpt-restrict-plugin-management-no" name="wpt_settings[restrict_plugin_management]" type="radio" value="0"<?php checked( 0, $restrict_plugin_management ); ?> />
-									<label for="wpt-restrict-plugin-management-no">
-										<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
-									</label>
-									<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete plugins.', 'wordpress-tools' ); ?></p>
-
-									<div class="wpt-whitelist-container" data-restriction="restrict_plugin_management"<?php echo $restrict_plugin_management ? '' : ' style="display:none"'; ?>>
-										<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
-										<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage plugins even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-										<?php $this->render_user_search_field( 'plugin_management_whitelist', $plugin_management_whitelist ); ?>
-									</div>
-								</fieldset>
+								<?php $this->render_plugin_management_restriction_field( $restrict_plugin_management, $plugin_management_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>
@@ -1001,24 +1098,7 @@ class Settings {
 								<?php esc_html_e( 'Restrict Theme Management', 'wordpress-tools' ); ?>
 							</th>
 							<td>
-								<fieldset>
-									<input id="wpt-restrict-theme-management-yes" name="wpt_settings[restrict_theme_management]" type="radio" value="1"<?php checked( 1, $restrict_theme_management ); ?> />
-									<label for="wpt-restrict-theme-management-yes">
-										<?php esc_html_e( 'Yes', 'wordpress-tools' ); ?>
-									</label><br>
-
-									<input id="wpt-restrict-theme-management-no" name="wpt_settings[restrict_theme_management]" type="radio" value="0"<?php checked( 0, $restrict_theme_management ); ?> />
-									<label for="wpt-restrict-theme-management-no">
-										<?php esc_html_e( 'No', 'wordpress-tools' ); ?>
-									</label>
-									<p class="description"><?php esc_html_e( 'Only allows administrators with @829llc.com emails to install, update, or delete themes.', 'wordpress-tools' ); ?></p>
-
-									<div class="wpt-whitelist-container" data-restriction="restrict_theme_management"<?php echo $restrict_theme_management ? '' : ' style="display:none"'; ?>>
-										<p class="description" style="margin: 0 0 4px;"><strong><?php esc_html_e( 'Whitelisted Users', 'wordpress-tools' ); ?></strong></p>
-										<p class="description" style="margin: 0 0 8px;"><?php esc_html_e( 'These users can manage themes even when restriction is enabled.', 'wordpress-tools' ); ?></p>
-										<?php $this->render_user_search_field( 'theme_management_whitelist', $theme_management_whitelist ); ?>
-									</div>
-								</fieldset>
+								<?php $this->render_theme_management_restriction_field( $restrict_theme_management, $theme_management_whitelist ); ?>
 							</td>
 						</tr>
 						<tr>

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -1143,7 +1143,7 @@ class Settings {
 		$is_disabled                = defined( 'WPT_DISABLE_COMMENTS' ) || has_filter( 'wpt_disable_comments' );
 		?>
 		<div class="wrap">
-			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<h1><?php echo esc_html( get_admin_page_title() . ' — v' . WPT_VERSION ); ?></h1>
 
 			<?php
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -1378,7 +1378,7 @@ class Settings {
 		}
 		?>
 		<div class="wrap">
-			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+			<h1><?php echo esc_html( get_admin_page_title() . ' — v' . WPT_VERSION ); ?></h1>
 			<form action="options.php" method="post">
 				<?php
 				settings_fields( 'wpt_829_settings' );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.9.0",
+	"version": "1.8.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.7.0",
+	"version": "1.8.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.1",
+	"version": "1.9.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.7.0
+ * Version: 1.8.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.1
+ * Version: 1.9.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -30,6 +30,7 @@ use WordPressTools\SiteInfo\ActivityLog;
 use WordPressTools\SiteInfo\SiteInfo;
 use WordPressTools\MCP\MCP;
 use WordPressTools\RoleManagement\RoleManagement;
+use WordPressTools\NoIndex\NoIndex;
 use WP_CLI;
 
 // Prevent direct access.
@@ -165,6 +166,7 @@ add_action(
 		API::instance();
 		MCP::instance();
 		RoleManagement::instance();
+		NoIndex::instance();
 	}
 );
 

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.9.0
+ * Version: 1.8.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WPT_VERSION', '1.6.1' );
+define( 'WPT_VERSION', '1.8.0' );
 define( 'WPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
Add Force No-Index on Staging and Dev Domains feature (v1.9.0)

Automatically injects `noindex, nofollow` meta tags and `X-Robots-Tag` headers on all frontend requests to staging and dev environments, preventing accidental search engine indexing.

Trigger conditions (domain checks override WP_ENVIRONMENT_TYPE):
- Domain suffix matches *.829dev.com, *.829stage.com, *.pec-dev.com, or *.pec-stage.com
- TLD is .local, .localhost, or .dev
- WP_ENVIRONMENT_TYPE is defined and set to anything other than 'production'

Settings page controls:
- Shows "Active" or "Temporarily Disabled" status badge
- Timed disable option (5 min / 15 min / 30 min / 1 hour) via AJAX
- Displays relative countdown when disabled ("Resumes in X minutes")
- Re-enable now button to restore enforcement early