### PR TITLE
Add NoIndex Banner feature for 829 users on production no-index pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+829 Studios WordPress Tools — a WordPress plugin providing SSO, security hardening, and admin customizations. Distributed as a plugin zip; updates are delivered from GitHub releases via `yahnis-elsts/plugin-update-checker`. There is no separate build step for PHP — the plugin runs from source once dependencies are installed.
+
+## Commands
+
+```bash
+composer install          # PHP deps (required for the plugin to load)
+npm install               # Dev deps (only needed to build the release zip)
+
+composer run lint         # phpcs against phpcs.xml (WordPress + VIP standards, PHP 7.4 target)
+composer run lint-fix     # phpcbf autofix
+
+npm run zip               # Build distributable zip (used by release workflow)
+```
+
+There is no test suite. Do not invent one — verify changes by running lint and by exercising the plugin in a WordPress install.
+
+### WP-CLI
+
+The plugin registers commands under `wp 829-tools` (see `includes/classes/Commands.php`). Example:
+
+```bash
+wp 829-tools clear-login-attempts
+```
+
+## Architecture
+
+### Bootstrap (`wordpress-tools.php`)
+
+Single entry file. Responsibilities, in order:
+
+1. Defines `WPT_*` constants — most are `if ( ! defined(...) )` guarded so `wp-config.php` can override before the plugin loads.
+2. Auto-detects `WP_ENVIRONMENT_TYPE` (`staging` for `*.829dev.com` / `*.wpenginepowered.com`, `development` for local TLDs via `Utils\is_local_environment()`).
+3. Detects WP Engine (`WPT_IS_WPE`) and network activation (`WPT_IS_NETWORK`).
+4. Registers a custom PSR-4-ish autoloader mapping `WordPressTools\Foo\Bar` → `includes/classes/Foo/Bar.php`. The `composer.json` `autoload` block declares the same mapping but the runtime loader in `wordpress-tools.php` is what's actually used. Also hardcodes a loader for `ZxcvbnPhp`.
+5. `PluginManagement::instance()` runs immediately (before `plugins_loaded`) because it needs to gate plugin/theme capabilities early. All other modules boot on the `plugins_loaded` action via `Module::instance()`.
+
+### Module pattern
+
+Every feature lives in `includes/classes/<Module>/<Module>.php` as a class using the `WordPressTools\Singleton` trait. `instance()` lazily constructs and calls `setup()`, which is where all `add_action`/`add_filter` hooks are registered. To add a new module: create the class, add its `use ...;` and `Module::instance();` line in `wordpress-tools.php`.
+
+Current modules (all in `includes/classes/`):
+
+- `SSO/` — 829 Studios SSO via proxy at `WPT_SSO_PROXY_URL`
+- `Authentication/` — `Passwords` (zxcvbn + HIBP), `Usernames` (reserved-name block), `LimitLogin` (transient-based IP throttling), `TwoFactor` (integrates with the Two-Factor plugin)
+- `Settings/` — centralized settings page; **the source of truth for feature toggles**. `Settings::get_settings()` returns all settings merged with defaults. Also owns the plugin's API key (auto-generated on activation and `admin_init`).
+- `PluginManagement/`, `Comments/`, `PostPasswords/`, `AdminCustomizations/`, `RoleManagement/`, `NoIndex/`, `API/` (REST API gating), `MCP/`, `SiteInfo/` (+ `ActivityLog`)
+- `Commands.php` — WP-CLI commands, registered under `829-tools`
+
+### Multisite / network awareness
+
+`WPT_IS_NETWORK` is set at bootstrap based on whether the plugin is network-activated. Two rules follow from this:
+
+- Settings pages: register under `network_admin_menu` when networked, `admin_menu` otherwise (see `Settings::setup()`).
+- Options: read/write via `WordPressTools\Utils\get_maybe_site_option()` which picks `get_site_option` vs `get_option` based on `WPT_IS_NETWORK`. Use this helper — don't call `get_option` directly for plugin settings.
+
+### 829 identity helpers
+
+`Utils\is_829_user()` and `Utils\is_829_admin()` (`includes/utils.php`) gate access to sensitive features by checking for an `@829llc.com` email. `is_829_admin` deliberately inspects `$user->roles` and `$user->allcaps` directly rather than calling `user_can()` to avoid infinite recursion inside `user_has_cap` filters — preserve that pattern in similar checks.
+
+### MCP module
+
+`MCP/MCP.php` no-ops unless both `WP\MCP\Core\McpAdapter` and `wp_register_ability()` (WordPress 6.9+) are available. Keep new abilities behind the same guards.
+
+## Conventions
+
+- **PHP 7.4 target.** `phpcs.xml` enforces this via `PHPCompatibilityWP`. Don't use 8.0+ syntax.
+- **WordPress coding standards** (WPCS + VIP) enforced by phpcs. Tabs for indentation; short array syntax is allowed (the `DisallowShortArraySyntax` rule is excluded).
+- **Namespaces:** all classes under `WordPressTools\`. Utility functions live in the `WordPressTools\Utils` namespace in `includes/utils.php` (not autoloaded — required directly at bootstrap).
+- **Settings additions:** add the default in `Settings::get_settings()` and register/sanitize it inside `Settings` — that array is the contract every module reads from.
+- **Version bumps:** the version appears in three places that must stay in sync: the plugin header in `wordpress-tools.php`, the `WPT_VERSION` constant, and `package.json`. The release zip filename is derived from `package.json` version (see `npm-scripts/add-zip-version.js` and `.github/workflows/plugin-zip.yml`).
+
+## Release flow
+
+Publishing a GitHub release triggers `.github/workflows/plugin-zip.yml`, which runs `composer install --no-dev`, `npm install`, `npm run zip`, and attaches `wordpress-tools-<version>.zip` to the release. Installed sites pick it up via the plugin-update-checker pointed at `https://github.com/829-studios/wordpress-tools/`.

--- a/includes/classes/NoIndexBanner/NoIndexBanner.php
+++ b/includes/classes/NoIndexBanner/NoIndexBanner.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * NoIndex Banner — frontend alert for 829 users on no-indexed production pages.
+ *
+ * @package  WordPressTools
+ */
+
+namespace WordPressTools\NoIndexBanner;
+
+use WordPressTools\Singleton;
+use WordPressTools\Settings\Settings;
+use function WordPressTools\Utils\is_829_user;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * NoIndexBanner class
+ *
+ * Displays a thin warning banner on the frontend when a page has noindex set
+ * on what appears to be a production domain. Only visible to logged-in 829 users.
+ */
+class NoIndexBanner {
+
+	use Singleton;
+
+	/**
+	 * Whether the current page has noindex set after all filters have run.
+	 *
+	 * @var bool
+	 */
+	private bool $page_is_noindex = false;
+
+	/**
+	 * Built-in domains (and the .local TLD) treated as staging/dev.
+	 * These are always excluded regardless of settings.
+	 *
+	 * @var string[]
+	 */
+	private const EXCLUDED_DOMAINS = [
+		'829dev.com',
+		'829stage.com',
+		'pec-dev.com',
+		'pec-stage.com',
+		'wpengine.com',
+		'wpenginepowered.com',
+		'local', // matches any *.local domain
+	];
+
+	/**
+	 * Setup hooks.
+	 */
+	public function setup() {
+		$settings = Settings::get_settings();
+
+		if ( ! $settings['noindex_banner_enabled'] || is_admin() || $this->is_excluded_domain( $settings ) ) {
+			return;
+		}
+
+		// Capture the final noindex state after every plugin has had its say.
+		add_filter( 'wp_robots', [ $this, 'capture_noindex_status' ], PHP_INT_MAX );
+		add_action( 'wp_footer', [ $this, 'maybe_render_banner' ] );
+	}
+
+	/**
+	 * Return true when the current domain is a known or user-defined staging/dev environment.
+	 *
+	 * @param  array $settings Plugin settings.
+	 * @return bool
+	 */
+	private function is_excluded_domain( array $settings ): bool {
+		$current_domain = strtolower( (string) wp_parse_url( site_url(), PHP_URL_HOST ) );
+
+		$all_excluded = array_merge(
+			self::EXCLUDED_DOMAINS,
+			array_filter( array_map( 'trim', (array) ( $settings['noindex_banner_excluded_domains'] ?? [] ) ) )
+		);
+
+		foreach ( $all_excluded as $domain ) {
+			$domain = strtolower( $domain );
+			$suffix = '.' . $domain;
+			if ( $current_domain === $domain || substr( $current_domain, -strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Record whether noindex is set after all wp_robots filters have run.
+	 *
+	 * @param  array $robots Robots directives.
+	 * @return array
+	 */
+	public function capture_noindex_status( array $robots ): array {
+		if ( ! empty( $robots['noindex'] ) ) {
+			$this->page_is_noindex = true;
+		}
+
+		return $robots;
+	}
+
+	/**
+	 * Render the banner if the page is noindex and the current user is a 829 employee.
+	 *
+	 * @return void
+	 */
+	public function maybe_render_banner(): void {
+		if ( ! $this->page_is_noindex || ! is_user_logged_in() || ! is_829_user() ) {
+			return;
+		}
+
+		$admin_bar = is_admin_bar_showing();
+		?>
+		<style>
+			#wpt-noindex-banner {
+				position: fixed;
+				top: 0;
+				left: 0;
+				right: 0;
+				z-index: 99998;
+				background: #b32d2e;
+				color: #fff;
+				font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
+				font-size: 13px;
+				font-weight: 500;
+				line-height: 1;
+				text-align: center;
+				padding: 9px 16px;
+				box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+			}
+			<?php if ( $admin_bar ) : ?>
+			body.admin-bar #wpt-noindex-banner {
+				top: 32px;
+			}
+			@media screen and (max-width: 782px) {
+				body.admin-bar #wpt-noindex-banner {
+					top: 46px;
+				}
+			}
+			<?php endif; ?>
+		</style>
+		<div id="wpt-noindex-banner" role="alert">
+			<?php esc_html_e( 'This page is set to no-index. This is believed to be a production domain.', 'wordpress-tools' ); ?>
+		</div>
+		<?php
+	}
+}

--- a/includes/classes/RoleManagement/RoleManagement.php
+++ b/includes/classes/RoleManagement/RoleManagement.php
@@ -57,6 +57,40 @@ class RoleManagement {
 	 */
 	public function setup() {
 		add_filter( 'user_has_cap', [ $this, 'grant_editor_caps' ], 10, 4 );
+		add_filter( 'map_meta_cap', [ $this, 'allow_editors_to_edit_privacy_policy' ], 10, 4 );
+	}
+
+	/**
+	 * Allow editors to edit and delete the privacy policy page.
+	 *
+	 * Core requires `manage_options` (or `manage_network` on multisite) to
+	 * edit or delete the privacy policy page. Strip those requirements so
+	 * users with the standard edit/delete page caps can manage it.
+	 *
+	 * @param array  $caps    The user's required primitive capabilities.
+	 * @param string $cap     Capability being checked.
+	 * @param int    $user_id The user ID.
+	 * @param array  $args    Context: [0] => object ID.
+	 * @return array
+	 */
+	public function allow_editors_to_edit_privacy_policy( $caps, $cap, $user_id, $args ) {
+		if ( ! in_array( $cap, [ 'edit_post', 'delete_post' ], true ) ) {
+			return $caps;
+		}
+
+		if ( empty( $args[0] ) ) {
+			return $caps;
+		}
+
+		$policy_id = (int) get_option( 'wp_page_for_privacy_policy' );
+
+		if ( 0 === $policy_id || (int) $args[0] !== $policy_id ) {
+			return $caps;
+		}
+
+		return array_values(
+			array_diff( $caps, [ 'manage_options', 'manage_network' ] )
+		);
 	}
 
 	/**

--- a/includes/classes/Settings/Settings.php
+++ b/includes/classes/Settings/Settings.php
@@ -65,6 +65,8 @@ class Settings {
 			'restrict_rest_api'              => 'users',
 			'limit_login'                    => 1,
 			'enable_mcp'                     => 1,
+			'noindex_banner_enabled'         => 1,
+			'noindex_banner_excluded_domains' => [],
 		];
 
 		// Get settings from single option
@@ -217,8 +219,10 @@ class Settings {
 					'restrict_theme_management'     => 1,
 					'theme_management_allow_list'    => [],
 					'restrict_rest_api'             => 'users',
-					'limit_login'                   => 1,
-					'enable_mcp'                    => 1,
+					'limit_login'                    => 1,
+					'enable_mcp'                     => 1,
+					'noindex_banner_enabled'         => 1,
+					'noindex_banner_excluded_domains' => [],
 				],
 			]
 		);
@@ -325,6 +329,15 @@ class Settings {
 			'wpt_noindex_status',
 			esc_html__( 'Force No-Index on Staging/Dev', 'wordpress-tools' ),
 			[ $this, 'noindex_status_setting_callback' ],
+			'wpt-829-settings',
+			'wpt_829_general_section'
+		);
+
+		// No-Index Banner setting field
+		add_settings_field(
+			'wpt_noindex_banner',
+			esc_html__( 'No-Index Banner', 'wordpress-tools' ),
+			[ $this, 'noindex_banner_setting_callback' ],
 			'wpt-829-settings',
 			'wpt_829_general_section'
 		);
@@ -748,6 +761,31 @@ class Settings {
 	}
 
 	/**
+	 * No-Index Banner setting callback.
+	 */
+	public function noindex_banner_setting_callback() {
+		$settings         = self::get_settings();
+		$enabled          = $settings['noindex_banner_enabled'];
+		$excluded_domains = $settings['noindex_banner_excluded_domains'] ?? [];
+		$domains_text     = implode( "\n", $excluded_domains );
+		?>
+		<fieldset>
+			<input id="wpt-noindex-banner-yes" name="wpt_settings[noindex_banner_enabled]" type="radio" value="1"<?php checked( 1, $enabled ); ?> />
+			<label for="wpt-noindex-banner-yes"><?php esc_html_e( 'Yes', 'wordpress-tools' ); ?></label><br>
+
+			<input id="wpt-noindex-banner-no" name="wpt_settings[noindex_banner_enabled]" type="radio" value="0"<?php checked( 0, $enabled ); ?> />
+			<label for="wpt-noindex-banner-no"><?php esc_html_e( 'No', 'wordpress-tools' ); ?></label>
+
+			<p class="description"><?php esc_html_e( 'Show a warning banner to logged-in 829 users when a page is set to no-index on a production domain.', 'wordpress-tools' ); ?></p>
+
+			<p class="description" style="margin: 12px 0 4px;"><strong><?php esc_html_e( 'Additional Excluded Domains', 'wordpress-tools' ); ?></strong></p>
+			<p class="description" style="margin: 0 0 6px;"><?php esc_html_e( 'One domain per line. The banner will not appear on these domains or their subdomains.', 'wordpress-tools' ); ?></p>
+			<textarea name="wpt_settings[noindex_banner_excluded_domains]" rows="4" class="large-text" style="max-width:400px;"><?php echo esc_textarea( $domains_text ); ?></textarea>
+		</fieldset>
+		<?php
+	}
+
+	/**
 	 * AJAX handler: temporarily disable noindex enforcement.
 	 */
 	public function ajax_noindex_disable() {
@@ -950,6 +988,20 @@ class Settings {
 
 		// Sanitize enable_mcp
 		$sanitized['enable_mcp'] = isset( $input['enable_mcp'] ) ? intval( $input['enable_mcp'] ) : 1;
+
+		// Sanitize noindex_banner_enabled
+		$sanitized['noindex_banner_enabled'] = isset( $input['noindex_banner_enabled'] ) ? intval( $input['noindex_banner_enabled'] ) : 1;
+
+		// Sanitize noindex_banner_excluded_domains — split textarea by newlines, trim, drop empties
+		if ( isset( $input['noindex_banner_excluded_domains'] ) && is_string( $input['noindex_banner_excluded_domains'] ) ) {
+			$sanitized['noindex_banner_excluded_domains'] = array_values(
+				array_filter(
+					array_map( 'sanitize_text_field', array_map( 'trim', explode( "\n", $input['noindex_banner_excluded_domains'] ) ) )
+				)
+			);
+		} else {
+			$sanitized['noindex_banner_excluded_domains'] = [];
+		}
 
 		return $sanitized;
 	}
@@ -1345,6 +1397,14 @@ class Settings {
 							</th>
 							<td>
 								<?php $this->render_noindex_status_field(); ?>
+							</td>
+						</tr>
+						<tr>
+							<th scope="row">
+								<?php esc_html_e( 'No-Index Banner', 'wordpress-tools' ); ?>
+							</th>
+							<td>
+								<?php $this->noindex_banner_setting_callback(); ?>
 							</td>
 						</tr>
 						<tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.1",
+	"version": "1.9.0",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WPT_VERSION', '1.8.0' );
+define( 'WPT_VERSION', '1.8.1' );
 define( 'WPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.9.0
+ * Version: 1.10.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -31,6 +31,7 @@ use WordPressTools\SiteInfo\SiteInfo;
 use WordPressTools\MCP\MCP;
 use WordPressTools\RoleManagement\RoleManagement;
 use WordPressTools\NoIndex\NoIndex;
+use WordPressTools\NoIndexBanner\NoIndexBanner;
 use WP_CLI;
 
 // Prevent direct access.
@@ -38,7 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WPT_VERSION', '1.9.0' );
+define( 'WPT_VERSION', '1.10.0' );
 define( 'WPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 
@@ -167,6 +168,7 @@ add_action(
 		MCP::instance();
 		RoleManagement::instance();
 		NoIndex::instance();
+		NoIndexBanner::instance();
 	}
 );
 

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.1
+ * Version: 1.9.0
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WPT_VERSION', '1.8.1' );
+define( 'WPT_VERSION', '1.9.0' );
 define( 'WPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
Introduces a new NoIndexBanner module that displays a thin red warning
banner on the frontend when a page has noindex set and the site appears
to be a production domain. The banner is only visible to logged-in
@829llc.com users and is suppressed on known staging/dev domains
(829dev.com, 829stage.com, pec-dev.com, pec-stage.com, *.local, WP
Engine hostnames).

Settings additions:
- Toggle to enable/disable the banner (default: enabled)
- Textarea for custom excluded domains (stored as an array, newline-
  delimited in the UI), merged with the built-in exclusion list at
  runtime
  
<img width="1705" height="899" alt="image" src="https://github.com/user-attachments/assets/6e2e47a9-15c5-449a-994d-ef8a9c59faea" />
