### PR TITLE
Nicole/mcp updates

### DIFF
--- a/includes/classes/MCP/MCP.php
+++ b/includes/classes/MCP/MCP.php
@@ -1422,9 +1422,8 @@ class MCP {
 	}
 
 	/**
-	 * Permission callback: read posts (list-posts, get-post). Granted to
-	 * administrators, MCP site managers, and anyone holding any of the
-	 * post-specific MCP capabilities.
+	 * Permission callback: read posts (list-posts, get-post). Execute
+	 * callbacks scope non-managers to their own posts only.
 	 *
 	 * @return true|WP_Error
 	 */
@@ -1451,7 +1450,8 @@ class MCP {
 	}
 
 	/**
-	 * Permission callback: edit existing posts.
+	 * Permission callback: edit existing posts. Non-managers may only edit
+	 * their own posts.
 	 *
 	 * @return true|WP_Error
 	 */
@@ -1524,6 +1524,15 @@ class MCP {
 	 * @return bool
 	 */
 	private function current_user_can_delete_posts() {
+		return $this->current_user_can_any( array( '829_mcp_manage_site', '829_mcp_delete_posts' ) );
+	}
+
+	/**
+	 * Whether the current user may act on posts belonging to other users.
+	 *
+	 * @return bool
+	 */
+	private function current_user_can_manage_any_post() {
 		return $this->current_user_can_any( array( '829_mcp_manage_site', '829_mcp_delete_posts' ) );
 	}
 
@@ -3098,6 +3107,11 @@ class MCP {
 			$args['author'] = intval( $input['author'] );
 		}
 
+		// Non-managers may only list their own posts.
+		if ( ! $this->current_user_can_manage_any_post() ) {
+			$args['author'] = get_current_user_id();
+		}
+
 		if ( ! empty( $input['terms'] ) && is_array( $input['terms'] ) ) {
 			$tax_query = array( 'relation' => 'AND' );
 			foreach ( $input['terms'] as $taxonomy => $term_values ) {
@@ -3145,6 +3159,10 @@ class MCP {
 
 		if ( ! $post ) {
 			return new WP_Error( 'not_found', "Post {$id} not found." );
+		}
+
+		if ( ! $this->current_user_can_manage_any_post() && get_current_user_id() !== (int) $post->post_author ) {
+			return new WP_Error( 'insufficient_permission', 'You do not have permission to view this post.' );
 		}
 
 		return array( 'post' => $this->format_post_detail( $post ) );
@@ -3231,6 +3249,10 @@ class MCP {
 
 		if ( ! $post ) {
 			return new WP_Error( 'not_found', "Post {$id} not found." );
+		}
+
+		if ( ! $this->current_user_can_manage_any_post() && get_current_user_id() !== (int) $post->post_author ) {
+			return new WP_Error( 'insufficient_permission', 'You do not have permission to edit this post.' );
 		}
 
 		$postarr = array( 'ID' => $id );

--- a/includes/classes/MCP/MCP.php
+++ b/includes/classes/MCP/MCP.php
@@ -1127,7 +1127,7 @@ class MCP {
 						'pages' => array( 'type' => 'integer' ),
 					),
 				),
-				'permission_callback' => [ $this, 'check_admin_permission' ],
+				'permission_callback' => [ $this, 'check_posts_read_permission' ],
 				'execute_callback'    => [ $this, 'list_posts' ],
 				'meta'                => array(
 					'mcp'         => array( 'public' => true ),
@@ -1162,7 +1162,7 @@ class MCP {
 						'post' => array( 'type' => 'object' ),
 					),
 				),
-				'permission_callback' => [ $this, 'check_admin_permission' ],
+				'permission_callback' => [ $this, 'check_posts_read_permission' ],
 				'execute_callback'    => [ $this, 'get_post_item' ],
 				'meta'                => array(
 					'mcp'         => array( 'public' => true ),
@@ -1241,7 +1241,7 @@ class MCP {
 						'post_id' => array( 'type' => 'integer' ),
 					),
 				),
-				'permission_callback' => [ $this, 'check_admin_permission' ],
+				'permission_callback' => [ $this, 'check_posts_create_permission' ],
 				'execute_callback'    => [ $this, 'create_post_item' ],
 				'meta'                => array(
 					'mcp'         => array( 'public' => true ),
@@ -1321,7 +1321,7 @@ class MCP {
 						'updated' => array( 'type' => 'boolean' ),
 					),
 				),
-				'permission_callback' => [ $this, 'check_admin_permission' ],
+				'permission_callback' => [ $this, 'check_posts_edit_permission' ],
 				'execute_callback'    => [ $this, 'update_post_item' ],
 				'meta'                => array(
 					'mcp'         => array( 'public' => true ),
@@ -1360,7 +1360,7 @@ class MCP {
 						'deleted' => array( 'type' => 'boolean' ),
 					),
 				),
-				'permission_callback' => [ $this, 'check_admin_permission' ],
+				'permission_callback' => [ $this, 'check_posts_delete_permission' ],
 				'execute_callback'    => [ $this, 'delete_post_item' ],
 				'meta'                => array(
 					'mcp'         => array( 'public' => true ),
@@ -1411,20 +1411,120 @@ class MCP {
 	}
 
 	/**
-	 * Permission callback: requires manage_options.
+	 * Permission callback: site administration tools (plugins, themes, users,
+	 * menus, options, media, redirects, ACF, blocks). Requires manage_options
+	 * or the MCP site management capability.
 	 *
 	 * @return true|WP_Error
 	 */
 	public function check_admin_permission() {
+		return $this->check_permission( array( '829_mcp_manage_site' ) );
+	}
+
+	/**
+	 * Permission callback: read posts (list-posts, get-post). Granted to
+	 * administrators, MCP site managers, and anyone holding any of the
+	 * post-specific MCP capabilities.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function check_posts_read_permission() {
+		return $this->check_permission(
+			array(
+				'829_mcp_manage_site',
+				'829_mcp_create_posts',
+				'829_mcp_edit_posts',
+				'829_mcp_publish_posts',
+				'829_mcp_delete_posts',
+			)
+		);
+	}
+
+	/**
+	 * Permission callback: create new posts. A user with only this capability
+	 * can create drafts but not publish, edit existing posts, or delete.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function check_posts_create_permission() {
+		return $this->check_permission( array( '829_mcp_manage_site', '829_mcp_create_posts' ) );
+	}
+
+	/**
+	 * Permission callback: edit existing posts.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function check_posts_edit_permission() {
+		return $this->check_permission( array( '829_mcp_manage_site', '829_mcp_edit_posts' ) );
+	}
+
+	/**
+	 * Permission callback: delete or trash posts.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function check_posts_delete_permission() {
+		return $this->check_permission( array( '829_mcp_manage_site', '829_mcp_delete_posts' ) );
+	}
+
+	/**
+	 * Checks that the current user is logged in and holds at least one of the
+	 * given capabilities. Administrators (manage_options) always pass.
+	 *
+	 * @param  string[] $capabilities Capabilities, any one of which grants access.
+	 * @return true|WP_Error
+	 */
+	private function check_permission( array $capabilities ) {
 		if ( ! is_user_logged_in() ) {
 			return new WP_Error( 'not_authenticated', 'Authentication required.' );
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error( 'insufficient_permission', 'Administrator access required.' );
+		if ( $this->current_user_can_any( $capabilities ) ) {
+			return true;
 		}
 
-		return true;
+		return new WP_Error( 'insufficient_permission', 'You do not have permission to use this tool.' );
+	}
+
+	/**
+	 * Whether the current user is an administrator or holds at least one of
+	 * the given capabilities.
+	 *
+	 * @param  string[] $capabilities Capabilities to check.
+	 * @return bool
+	 */
+	private function current_user_can_any( array $capabilities ) {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		foreach ( $capabilities as $capability ) {
+			if ( current_user_can( $capability ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the current user may publish posts (set status to "publish"
+	 * or "future") via MCP.
+	 *
+	 * @return bool
+	 */
+	private function current_user_can_publish_posts() {
+		return $this->current_user_can_any( array( '829_mcp_manage_site', '829_mcp_publish_posts' ) );
+	}
+
+	/**
+	 * Whether the current user may delete or trash posts via MCP.
+	 *
+	 * @return bool
+	 */
+	private function current_user_can_delete_posts() {
+		return $this->current_user_can_any( array( '829_mcp_manage_site', '829_mcp_delete_posts' ) );
 	}
 
 	/**
@@ -3057,9 +3157,15 @@ class MCP {
 	 * @return array|WP_Error
 	 */
 	public function create_post_item( $input = array() ) {
+		$status = ! empty( $input['status'] ) ? $input['status'] : 'draft';
+
+		if ( in_array( $status, array( 'publish', 'future' ), true ) && ! $this->current_user_can_publish_posts() ) {
+			return new WP_Error( 'insufficient_permission', 'You do not have permission to publish posts.' );
+		}
+
 		$postarr = array(
 			'post_type'   => ! empty( $input['post_type'] ) ? sanitize_key( $input['post_type'] ) : 'post',
-			'post_status' => ! empty( $input['status'] ) ? $input['status'] : 'draft',
+			'post_status' => $status,
 		);
 
 		if ( isset( $input['title'] ) ) {
@@ -3142,6 +3248,14 @@ class MCP {
 		}
 
 		if ( isset( $input['status'] ) ) {
+			if ( in_array( $input['status'], array( 'publish', 'future' ), true ) && ! $this->current_user_can_publish_posts() ) {
+				return new WP_Error( 'insufficient_permission', 'You do not have permission to publish posts.' );
+			}
+
+			if ( 'trash' === $input['status'] && ! $this->current_user_can_delete_posts() ) {
+				return new WP_Error( 'insufficient_permission', 'You do not have permission to delete posts.' );
+			}
+
 			$postarr['post_status'] = $input['status'];
 		}
 

--- a/includes/classes/Roles.php
+++ b/includes/classes/Roles.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Custom roles and capabilities used by this plugin.
+ *
+ * @package  WordPressTools
+ */
+
+namespace WordPressTools;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Roles class
+ */
+class Roles {
+
+	/**
+	 * Option storing the version of the role definitions that were last
+	 * written to the database. Bump self::VERSION to force a refresh.
+	 *
+	 * WordPress stores roles per site, so this is intentionally a site option
+	 * rather than a network option — each site in a multisite install needs
+	 * its own roles written.
+	 *
+	 * @var string
+	 */
+	private const VERSION_OPTION = 'wpt_roles_version';
+
+	/**
+	 * Current role definition version.
+	 *
+	 * @var string
+	 */
+	private const VERSION = '1';
+
+	/**
+	 * Role definitions, keyed by role slug.
+	 *
+	 * @return array<string, array{name: string, capabilities: string[]}>
+	 */
+	public static function get_role_definitions() {
+		return array(
+			'829_mcp_contributor' => array(
+				'name'         => 'MCP Contributor',
+				'capabilities' => array(
+					'829_mcp_create_posts',
+				),
+			),
+			'829_mcp_author'      => array(
+				'name'         => 'MCP Author',
+				'capabilities' => array(
+					'829_mcp_create_posts',
+					'829_mcp_edit_posts',
+					'829_mcp_publish_posts',
+				),
+			),
+			'829_mcp_editor'      => array(
+				'name'         => 'MCP Editor',
+				'capabilities' => array(
+					'829_mcp_create_posts',
+					'829_mcp_edit_posts',
+					'829_mcp_publish_posts',
+					'829_mcp_delete_posts',
+				),
+			),
+			'829_mcp_manager'     => array(
+				'name'         => 'MCP Site Manager',
+				'capabilities' => array(
+					'829_mcp_manage_site',
+					'829_mcp_create_posts',
+					'829_mcp_edit_posts',
+					'829_mcp_publish_posts',
+					'829_mcp_delete_posts',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Register the custom roles if they are missing or out of date.
+	 *
+	 * Safe to call on every request; it only touches the database when the
+	 * stored version doesn't match the current definitions.
+	 */
+	public static function maybe_register_roles() {
+		if ( self::VERSION === get_option( self::VERSION_OPTION ) ) {
+			return;
+		}
+
+		self::register_roles();
+
+		update_option( self::VERSION_OPTION, self::VERSION );
+	}
+
+	/**
+	 * Create or refresh the custom roles.
+	 *
+	 * Existing roles are updated in place rather than removed and recreated,
+	 * so users already assigned to them keep their role.
+	 */
+	public static function register_roles() {
+		foreach ( self::get_role_definitions() as $slug => $definition ) {
+			// Every role needs `read` so the user can authenticate and load
+			// the profile screen.
+			$capabilities = array( 'read' => true );
+
+			foreach ( $definition['capabilities'] as $capability ) {
+				$capabilities[ $capability ] = true;
+			}
+
+			$role = get_role( $slug );
+
+			if ( ! $role ) {
+				add_role( $slug, $definition['name'], $capabilities );
+				continue;
+			}
+
+			// Add anything missing and strip capabilities no longer in the definition.
+			foreach ( array_keys( $capabilities ) as $capability ) {
+				if ( ! $role->has_cap( $capability ) ) {
+					$role->add_cap( $capability );
+				}
+			}
+
+			foreach ( self::get_all_capabilities() as $capability ) {
+				if ( ! isset( $capabilities[ $capability ] ) && $role->has_cap( $capability ) ) {
+					$role->remove_cap( $capability );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Remove the custom roles. Intended for uninstall.
+	 */
+	public static function remove_roles() {
+		foreach ( array_keys( self::get_role_definitions() ) as $slug ) {
+			remove_role( $slug );
+		}
+
+		delete_option( self::VERSION_OPTION );
+	}
+
+	/**
+	 * All capabilities defined by this plugin, collected from the role definitions.
+	 *
+	 * @return string[]
+	 */
+	public static function get_all_capabilities() {
+		$capabilities = array();
+
+		foreach ( self::get_role_definitions() as $definition ) {
+			$capabilities = array_merge( $capabilities, $definition['capabilities'] );
+		}
+
+		return array_values( array_unique( $capabilities ) );
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wordpress-tools",
-	"version": "1.8.1",
+	"version": "1.8.2",
 	"description": "WordPress tools for 829 Studios. A comprehensive WordPress security and management plugin designed to enhance site security, streamline authentication, and provide centralized control over critical WordPress features.",
 	"author": "829 Studios",
 	"license": "MIT",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -98,6 +98,19 @@
 		</properties>
 	</rule>
 
+	<!-- Custom capabilities registered by this plugin (see MCP\Roles). -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="829_mcp_manage_site"/>
+				<element value="829_mcp_create_posts"/>
+				<element value="829_mcp_edit_posts"/>
+				<element value="829_mcp_publish_posts"/>
+				<element value="829_mcp_delete_posts"/>
+			</property>
+		</properties>
+	</rule>
+
 	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed">
         <exclude-pattern>.*</exclude-pattern>
     </rule>

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -29,6 +29,7 @@ use WordPressTools\API\API;
 use WordPressTools\SiteInfo\ActivityLog;
 use WordPressTools\SiteInfo\SiteInfo;
 use WordPressTools\MCP\MCP;
+use WordPressTools\Roles;
 use WordPressTools\RoleManagement\RoleManagement;
 use WordPressTools\NoIndex\NoIndex;
 use WP_CLI;
@@ -173,10 +174,19 @@ add_action(
 // Generate an API key on activation if one doesn't exist.
 register_activation_hook( __FILE__, [ Settings::class, 'maybe_generate_api_key' ] );
 
+// Create the MCP roles on activation.
+register_activation_hook( __FILE__, [ Roles::class, 'register_roles' ] );
+
 // On admin load, ensure an API key exists (covers plugin updates).
 add_action(
 	'admin_init',
 	[ Settings::class, 'maybe_generate_api_key' ]
+);
+
+// On admin load, ensure the MCP roles exist and are current (covers plugin updates).
+add_action(
+	'admin_init',
+	[ Roles::class, 'maybe_register_roles' ]
 );
 
 // Register WP-CLI commands

--- a/wordpress-tools.php
+++ b/wordpress-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: 829 Studios - WordPress Tools
  * Plugin URI: https://www.829studios.com/
  * Description: WordPress tools for 829 Studios.
- * Version: 1.8.1
+ * Version: 1.8.2
  * Author: 829 Studios
  * Author URI: https://www.829studios.com/
  * Text Domain: 829-wordpress-tools
@@ -39,7 +39,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WPT_VERSION', '1.8.1' );
+define( 'WPT_VERSION', '1.8.2' );
 define( 'WPT_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'WPT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 


### PR DESCRIPTION
Add granular MCP roles and capabilities for post access

Replaces the previous admin-only gate on MCP tools with four new WordPress roles and capability-based permission checks.

New roles:
- MCP Contributor — create posts only
- MCP Author — create, edit, and publish posts
- MCP Editor — create, edit, publish, and delete posts; can access every post, not just their own

New capabilities:
- 829_mcp_create_posts
- 829_mcp_edit_posts
- 829_mcp_publish_posts
- 829_mcp_delete_posts
- 829_mcp_manage_site

Behavior changes:
- Post endpoints (list, get, create, update, delete) now check for the specific capability required instead of manage_options.
- Non-manager roles (Contributor, Author) are scoped to only view and edit their own posts — only Editor and Site Manager can access every post.
- Site administration tools remain gated behind manage_options or the new 829_mcp_manage_site capability.
- Roles are registered on activation and kept in sync on admin_init via a versioned Roles class, so existing installs pick up role changes on update without needing reactivation.